### PR TITLE
lock backup/restore app to specify version

### DIFF
--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -86,6 +86,7 @@ class Migrate
                         'backupId' => $backupId,
                     ],
                 ],
+                'tag' => '1.3.0',
             ]
         );
         if ($job['status'] !== self::JOB_STATUS_SUCCESS) {
@@ -109,6 +110,7 @@ class Migrate
                         'useDefaultBackend' => true,
                     ],
                 ],
+                'tag' => '1.3.3',
             ]
         );
         if ($job['status'] !== self::JOB_STATUS_SUCCESS) {

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -50,6 +50,7 @@ class MigrateTest extends TestCase
                                 'useDefaultBackend' => true,
                             ],
                         ],
+                        'tag' => '1.3.3',
                     ],
                 ],
                 // restore snowflake writers
@@ -236,6 +237,7 @@ class MigrateTest extends TestCase
                             'backupId' => '123',
                         ],
                     ],
+                    'tag' => '1.3.0',
                 ]
             )
             ->willReturn($return)


### PR DESCRIPTION
Restore appka má BC break ve vstupní konfiguraci, takže abychom to mohli nasadit "bezvýpadkově" tak nejdříve to tu zamkneme na aktuální verzi

potom releasneme backup/restore appky

a nakonec tu nasadíme další PR který bude mít už upravený konfig a zase latest version na backup/restore appky