### PR TITLE
Fix improperly renamed docker env variables KBC_URL & KBC_TOKEN

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -84,16 +84,16 @@ jobs:
       -
         name: Run tests
         env:
+          KBC_URL: ${{env.DEST_PROJECT_URL}}
+          KBC_TOKEN: ${{env.DEST_STORAGE_API_TOKEN}}
+          KBC_TOKEN_NOT_MASTER: ${{env.DEST_STORAGE_API_TOKEN_NOT_MASTER}}
           SOURCE_STORAGE_API_ADMIN_TOKEN: ${{env.SOURCE_STORAGE_API_ADMIN_TOKEN}}
           SOURCE_PROJECT_URL: ${{env.SOURCE_PROJECT_URL}}
-          DEST_STORAGE_API_TOKEN: ${{env.DEST_STORAGE_API_TOKEN}}
-          DEST_STORAGE_API_TOKEN_NOT_MASTER: ${{env.DEST_STORAGE_API_TOKEN_NOT_MASTER}}
-          DEST_PROJECT_URL: ${{env.DEST_PROJECT_URL}}
         run: |
           docker run \
-          -e DEST_PROJECT_URL \
-          -e DEST_STORAGE_API_TOKEN \
-          -e DEST_STORAGE_API_TOKEN_NOT_MASTER \
+          -e KBC_URL \
+          -e KBC_TOKEN \
+          -e KBC_TOKEN_NOT_MASTER \
           -e SOURCE_PROJECT_URL \
           -e SOURCE_STORAGE_API_ADMIN_TOKEN \
           ${{env.APP_IMAGE}} composer ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       - ./:/code
       - ./data:/data
     environment:
-      - DEST_PROJECT_URL
-      - DEST_STORAGE_API_TOKEN
-      - DEST_STORAGE_API_TOKEN_NOT_MASTER
+      - KBC_URL
+      - KBC_TOKEN
+      - KBC_TOKEN_NOT_MASTER
       - SOURCE_PROJECT_URL
       - SOURCE_STORAGE_API_ADMIN_TOKEN

--- a/src/Component.php
+++ b/src/Component.php
@@ -32,8 +32,8 @@ class Component extends BaseComponent
         }
 
         $destProjectClient = $this->createStorageClient([
-            'url' => getenv('DEST_PROJECT_URL'),
-            'token' => getenv('DEST_STORAGE_API_TOKEN'),
+            'url' => getenv('KBC_URL'),
+            'token' => getenv('KBC_TOKEN'),
         ]);
 
         try {

--- a/tests/functional/DatadirTest.php
+++ b/tests/functional/DatadirTest.php
@@ -12,7 +12,7 @@ class DatadirTest extends DatadirTestCase
     {
         parent::setUp();
 
-        $nonMasterDestToken = getenv('DEST_STORAGE_API_TOKEN_NOT_MASTER');
-        putenv('DEST_STORAGE_API_TOKEN=' . $nonMasterDestToken);
+        $nonMasterDestToken = getenv('KBC_TOKEN_NOT_MASTER');
+        putenv('KBC_TOKEN=' . $nonMasterDestToken);
     }
 }


### PR DESCRIPTION
Fix improperly renamed docker env variables `KBC_URL` & `KBC_TOKEN` in previous PR https://github.com/keboola/app-project-migrate/pull/47