### PR TITLE
PST-2400: Handle encryption-api errors during secrets migration

### DIFF
--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -183,7 +183,7 @@ class Migrate
 
     private function migrateSecrets(): void
     {
-        $this->logger->info('Migrating configurations with secrets', ['secrets']);
+        $this->logger->info('Migrating configurations with secrets');
 
         $sourceDevBranches = new DevBranches($this->sourceProjectStorageClient);
         $sourceBranches = $sourceDevBranches->listBranches();
@@ -192,28 +192,28 @@ class Migrate
         $sourceComponentsApi = new Components($this->sourceProjectStorageClient);
         $components = $sourceComponentsApi->listComponents();
         if (!$components) {
-            $this->logger->info('There are no components to migrate.', ['secrets']);
+            $this->logger->info('There are no components to migrate.');
             return;
         }
 
         foreach ($components as $component) {
             if (in_array($component['id'], self::OBSOLETE_COMPONENTS, true)) {
-                $this->logger->info(
-                    sprintf('Components "%s" is obsolete, skipping migration...', $component['id']),
-                    ['secrets']
-                );
+                $this->logger->info('Components "{componentId}" is obsolete, skipping migration...', [
+                    'componentId' => $component['id'],
+                ]);
                 continue;
             }
 
             foreach ($component['configurations'] as $config) {
                 $this->logger->info(
                     sprintf(
-                        '%sMigrating configuration "%s" of component "%s"',
+                        '%sMigrating configuration "{configId}" of component "{componentId}"',
                         $this->dryRun ? '[dry-run] ' : '',
-                        $config['id'],
-                        $component['id'],
                     ),
-                    ['secrets'],
+                    [
+                        'configId' => $config['id'],
+                        'componentId' => $component['id'],
+                    ],
                 );
                 $response = $this->migrationsClient
                     ->migrateConfiguration(
@@ -240,11 +240,11 @@ class Migrate
                     $message = '[dry-run] ' . $message;
                 }
 
-                $this->logger->info($message, ['secrets']);
+                $this->logger->info($message);
 
                 if (isset($response['warnings']) && is_array($response['warnings'])) {
                     foreach ($response['warnings'] as $warning) {
-                        $this->logger->warning($warning, ['secrets']);
+                        $this->logger->warning($warning);
                     }
                 }
             }
@@ -383,15 +383,12 @@ class Migrate
 
             $destinationComponentsApi->updateConfiguration($destinationConfiguration);
 
-            $this->logger->info(
-                sprintf(
-                    "Used existing Snowflake workspace '%s' for configuration with ID '%s' (%s).",
-                    $migratedWorkspaceParameters['user'],
-                    $destinationConfigurationId,
-                    $destinationComponentId,
-                ),
-                ['secrets']
-            );
+            $this->logger->info('Used existing Snowflake workspace "{workspace}" '
+                . 'for configuration with ID "{configId}" ({componentId}).', [
+                'workspace' => $migratedWorkspaceParameters['user'],
+                'configId' => $destinationConfigurationId,
+                'componentId' => $destinationComponentId,
+            ]);
             return;
         }
 

--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -215,16 +215,32 @@ class Migrate
                         'componentId' => $component['id'],
                     ],
                 );
-                $response = $this->migrationsClient
-                    ->migrateConfiguration(
-                        $this->sourceProjectToken,
-                        Utils::getStackFromProjectUrl($this->destinationProjectUrl),
-                        $this->destinationProjectToken,
-                        $component['id'],
-                        $config['id'],
-                        (string) $defaultSourceBranch['id'],
-                        $this->dryRun
+
+                try {
+                    $response = $this->migrationsClient
+                        ->migrateConfiguration(
+                            $this->sourceProjectToken,
+                            Utils::getStackFromProjectUrl($this->destinationProjectUrl),
+                            $this->destinationProjectToken,
+                            $component['id'],
+                            $config['id'],
+                            (string) $defaultSourceBranch['id'],
+                            $this->dryRun
+                        );
+                } catch (EncryptionClientException $e) {
+                    $this->logger->error(
+                        sprintf(
+                            'Migrating configuration "%s" of component "%s" failed: %s',
+                            $config['id'],
+                            $component['id'],
+                            $e->getMessage()
+                        ),
+                        [
+                            'exception' => $e,
+                        ],
                     );
+                    continue;
+                }
 
                 if (in_array($component['id'], self::SNOWFLAKE_WRITER_COMPONENT_IDS, true)) {
                     $this->preserveProperSnowflakeWorkspace(

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -331,45 +331,56 @@ class MigrateTest extends TestCase
 
         $migrate->run();
 
-        $records = array_filter(
-            $logsHandler->getRecords(),
-            fn(array $record) => in_array('secrets', $record['context'] ?? [], true)
+        self::assertTrue(
+            $logsHandler->hasInfo('Migrating configurations with secrets'),
         );
-        self::assertCount(8, $records);
 
-        $record = array_shift($records);
-        self::assertSame('Migrating configurations with secrets', $record['message']);
-        $record = array_shift($records);
-        self::assertSame('Components "gooddata-writer" is obsolete, skipping migration...', $record['message']);
-        $record = array_shift($records);
-        self::assertSame(
-            'Migrating configuration "101" of component "some-component"',
-            $record['message']
+        self::assertTrue(
+            $logsHandler->hasInfo([
+                'message' => 'Components "{componentId}" is obsolete, skipping migration...',
+                'context' => [
+                    'componentId' => 'gooddata-writer',
+                ],
+            ]),
         );
-        $record = array_shift($records);
-        self::assertSame(
-            'Configuration with ID \'101\' successfully migrated to stack \'dest-stack\'.',
-            $record['message']
+
+        self::assertTrue(
+            $logsHandler->hasInfo([
+                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
+                'context' => [
+                    'configId' => '101',
+                    'componentId' => 'some-component',
+                ],
+            ]),
         );
-        $record = array_shift($records);
-        self::assertSame(
-            'Migrating configuration "102" of component "some-component"',
-            $record['message']
+        self::assertTrue(
+            $logsHandler->hasInfo('Configuration with ID \'101\' successfully migrated to stack \'dest-stack\'.'),
         );
-        $record = array_shift($records);
-        self::assertSame(
-            'Configuration with ID \'102\' successfully migrated to stack \'dest-stack\'.',
-            $record['message']
+
+        self::assertTrue(
+            $logsHandler->hasInfo([
+                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
+                'context' => [
+                    'configId' => '102',
+                    'componentId' => 'some-component',
+                ],
+            ]),
         );
-        $record = array_shift($records);
-        self::assertSame(
-            'Migrating configuration "201" of component "another-component"',
-            $record['message']
+        self::assertTrue(
+            $logsHandler->hasInfo('Configuration with ID \'102\' successfully migrated to stack \'dest-stack\'.'),
         );
-        $record = array_shift($records);
-        self::assertSame(
-            'Configuration with ID \'201\' successfully migrated to stack \'dest-stack\'.',
-            $record['message']
+
+        self::assertTrue(
+            $logsHandler->hasInfo([
+                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
+                'context' => [
+                    'configId' => '201',
+                    'componentId' => 'another-component',
+                ],
+            ]),
+        );
+        self::assertTrue(
+            $logsHandler->hasInfo('Configuration with ID \'201\' successfully migrated to stack \'dest-stack\'.'),
         );
     }
 
@@ -551,49 +562,58 @@ class MigrateTest extends TestCase
 
         $migrate->run();
 
-        $records = array_filter(
-            $logsHandler->getRecords(),
-            fn(array $record) => in_array('secrets', $record['context'] ?? [], true)
+        self::assertTrue(
+            $logsHandler->hasInfo('Migrating configurations with secrets'),
         );
-        self::assertCount(8, $records);
 
-        $record = array_shift($records);
-        self::assertSame('Migrating configurations with secrets', $record['message']);
-        $record = array_shift($records);
-        self::assertSame(
-            'Migrating configuration "101" of component "keboola.wr-db-snowflake"',
-            $record['message']
+        self::assertTrue(
+            $logsHandler->hasInfo([
+                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
+                'context' => [
+                    'configId' => '101',
+                    'componentId' => 'keboola.wr-db-snowflake',
+                ],
+            ]),
         );
-        $record = array_shift($records);
-        self::assertSame(
-            'Configuration with ID \'101\' successfully migrated to stack \'dest-stack\'.',
-            $record['message']
+        self::assertTrue(
+            $logsHandler->hasInfo('Configuration with ID \'101\' successfully migrated to stack \'dest-stack\'.'),
         );
-        $record = array_shift($records);
-        self::assertSame(
-            'Migrating configuration "102" of component "keboola.wr-db-snowflake"',
-            $record['message']
+
+        self::assertTrue(
+            $logsHandler->hasInfo([
+                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
+                'context' => [
+                    'configId' => '102',
+                    'componentId' => 'keboola.wr-db-snowflake',
+                ],
+            ]),
         );
-        $record = array_shift($records);
-        self::assertSame(
-            'Configuration with ID \'102\' successfully migrated to stack \'dest-stack\'.',
-            $record['message']
+        self::assertTrue(
+            $logsHandler->hasInfo('Configuration with ID \'102\' successfully migrated to stack \'dest-stack\'.'),
         );
-        $record = array_shift($records);
-        self::assertSame(
-            'Migrating configuration "103" of component "keboola.wr-db-snowflake"',
-            $record['message']
+
+        self::assertTrue(
+            $logsHandler->hasInfo([
+                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
+                'context' => [
+                    'configId' => '102',
+                    'componentId' => 'keboola.wr-db-snowflake',
+                ],
+            ]),
         );
-        $record = array_shift($records);
-        self::assertSame(
-            'Used existing Snowflake workspace \'USER_01\' for configuration with ID \'103\' '
-            . '(keboola.wr-db-snowflake).',
-            $record['message']
+        self::assertTrue(
+            $logsHandler->hasInfo([
+                'message' => 'Used existing Snowflake workspace "{workspace}" for configuration '
+                    . 'with ID "{configId}" ({componentId}).',
+                'context' => [
+                    'workspace' => 'USER_01',
+                    'configId' => '103',
+                    'componentId' => 'keboola.wr-db-snowflake',
+                ],
+            ]),
         );
-        $record = array_shift($records);
-        self::assertSame(
-            'Configuration with ID \'103\' successfully migrated to stack \'dest-stack\'.',
-            $record['message']
+        self::assertTrue(
+            $logsHandler->hasInfo('Configuration with ID \'103\' successfully migrated to stack \'dest-stack\'.'),
         );
     }
 

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -13,6 +13,7 @@ use Keboola\AppProjectMigrate\JobRunner\QueueV2JobRunner;
 use Keboola\AppProjectMigrate\JobRunner\SyrupJobRunner;
 use Keboola\AppProjectMigrate\Migrate;
 use Keboola\Component\UserException;
+use Keboola\EncryptionApiClient\Exception\ClientException as EncryptionClientException;
 use Keboola\EncryptionApiClient\Migrations;
 use Keboola\StorageApi\Client as StorageClient;
 use Keboola\Syrup\ClientException;
@@ -611,6 +612,151 @@ class MigrateTest extends TestCase
                     'componentId' => 'keboola.wr-db-snowflake',
                 ],
             ]),
+        );
+        self::assertTrue(
+            $logsHandler->hasInfo('Configuration with ID \'103\' successfully migrated to stack \'dest-stack\'.'),
+        );
+    }
+
+    public function testMigrateShouldHandleEncryptionApiErrorResponse(): void
+    {
+        $sourceJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
+        $destJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
+
+        // generate credentials
+        $this->mockAddMethodGenerateAbsReadCredentials($sourceJobRunnerMock);
+        $this->mockAddMethodBackupProject(
+            $sourceJobRunnerMock,
+            [
+                'id' => '222',
+                'status' => 'success',
+            ],
+            true
+        );
+
+        $destJobRunnerMock->method('runJob')
+            ->willReturn([
+                'id' => '222',
+                'status' => 'success',
+            ]);
+
+        $config = new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => 'https://connection.keboola.com',
+                    '#sourceKbcToken' => 'xyz',
+                    'migrateSecrets' => true,
+                    '#sourceManageToken' => 'manage-token',
+                ],
+            ],
+            new ConfigDefinition()
+        );
+
+        $logsHandler = new TestHandler();
+        $logger = new Logger('tests', [$logsHandler]);
+
+        $sourceClientMock = $this->createMock(StorageClient::class);
+        $sourceClientMock
+            ->method('apiGet')
+            ->willReturnMap([
+                [
+                    'dev-branches/', null, [],
+                    [
+                        [
+                            'id' => '123',
+                            'name' => 'default',
+                            'isDefault' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'components?include=', null, [],
+                    [
+                        [
+                            'id' => 'some-component',
+                            'configurations' => [
+                                [
+                                    'id' => '101',
+                                ],
+                                [
+                                    'id' => '666',
+                                ],
+                                [
+                                    'id' => '103',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+        ;
+        $sourceClientMock
+            ->method('getServiceUrl')
+            ->with('encryption')
+            ->willReturn('https://encryption.keboola.com')
+        ;
+
+        $destClientMock = $this->createMock(StorageClient::class);
+
+        $encryptionApiException = new EncryptionClientException('Something went wrong');
+
+        $migrationsClientMock = $this->createMock(Migrations::class);
+        $migrationsClientMock
+            ->expects(self::exactly(3))
+            ->method('migrateConfiguration')
+            ->willReturnCallback(function (...$args) use ($encryptionApiException) {
+                [, $destinationStack, , , $configId] = $args;
+                if ($configId === '666') {
+                    throw $encryptionApiException;
+                }
+                return [
+                    'message' => "Configuration with ID '$configId' successfully " .
+                        "migrated to stack '$destinationStack'.",
+                    'data' => [],
+                ];
+            });
+
+        /** @var JobRunner $sourceJobRunnerMock */
+        /** @var JobRunner $destJobRunnerMock */
+        $migrate = new Migrate(
+            $config,
+            $sourceJobRunnerMock,
+            $destJobRunnerMock,
+            $sourceClientMock,
+            $destClientMock,
+            $migrationsClientMock,
+            'https://dest-stack/',
+            'dest-token',
+            $logger,
+        );
+
+        $migrate->run();
+
+        self::assertTrue(
+            $logsHandler->hasInfo('Migrating configurations with secrets'),
+        );
+
+        self::assertTrue(
+            $logsHandler->hasInfo('Migrating configuration "101" of component "some-component"'),
+        );
+        self::assertTrue(
+            $logsHandler->hasInfo('Configuration with ID \'101\' successfully migrated to stack \'dest-stack\'.'),
+        );
+
+        self::assertTrue(
+            $logsHandler->hasInfo('Migrating configuration "666" of component "some-component"'),
+        );
+        self::assertTrue(
+            $logsHandler->hasError([
+                'message' => 'Migrating configuration "666" of component "some-component" failed: Something went wrong',
+                'context' => [
+                    'exception' => $encryptionApiException,
+                ],
+            ]),
+        );
+
+        self::assertTrue(
+            $logsHandler->hasInfo('Migrating configuration "103" of component "some-component"'),
         );
         self::assertTrue(
             $logsHandler->hasInfo('Configuration with ID \'103\' successfully migrated to stack \'dest-stack\'.'),

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -332,56 +332,45 @@ class MigrateTest extends TestCase
 
         $migrate->run();
 
-        self::assertTrue(
-            $logsHandler->hasInfo('Migrating configurations with secrets'),
+        $records = array_filter(
+            $logsHandler->getRecords(),
+            fn(array $record) => in_array('secrets', $record['context'] ?? [], true)
         );
+        self::assertCount(8, $records);
 
-        self::assertTrue(
-            $logsHandler->hasInfo([
-                'message' => 'Components "{componentId}" is obsolete, skipping migration...',
-                'context' => [
-                    'componentId' => 'gooddata-writer',
-                ],
-            ]),
+        $record = array_shift($records);
+        self::assertSame('Migrating configurations with secrets', $record['message']);
+        $record = array_shift($records);
+        self::assertSame('Components "gooddata-writer" is obsolete, skipping migration...', $record['message']);
+        $record = array_shift($records);
+        self::assertSame(
+            'Migrating configuration "101" of component "some-component"',
+            $record['message']
         );
-
-        self::assertTrue(
-            $logsHandler->hasInfo([
-                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
-                'context' => [
-                    'configId' => '101',
-                    'componentId' => 'some-component',
-                ],
-            ]),
+        $record = array_shift($records);
+        self::assertSame(
+            'Configuration with ID \'101\' successfully migrated to stack \'dest-stack\'.',
+            $record['message']
         );
-        self::assertTrue(
-            $logsHandler->hasInfo('Configuration with ID \'101\' successfully migrated to stack \'dest-stack\'.'),
+        $record = array_shift($records);
+        self::assertSame(
+            'Migrating configuration "102" of component "some-component"',
+            $record['message']
         );
-
-        self::assertTrue(
-            $logsHandler->hasInfo([
-                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
-                'context' => [
-                    'configId' => '102',
-                    'componentId' => 'some-component',
-                ],
-            ]),
+        $record = array_shift($records);
+        self::assertSame(
+            'Configuration with ID \'102\' successfully migrated to stack \'dest-stack\'.',
+            $record['message']
         );
-        self::assertTrue(
-            $logsHandler->hasInfo('Configuration with ID \'102\' successfully migrated to stack \'dest-stack\'.'),
+        $record = array_shift($records);
+        self::assertSame(
+            'Migrating configuration "201" of component "another-component"',
+            $record['message']
         );
-
-        self::assertTrue(
-            $logsHandler->hasInfo([
-                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
-                'context' => [
-                    'configId' => '201',
-                    'componentId' => 'another-component',
-                ],
-            ]),
-        );
-        self::assertTrue(
-            $logsHandler->hasInfo('Configuration with ID \'201\' successfully migrated to stack \'dest-stack\'.'),
+        $record = array_shift($records);
+        self::assertSame(
+            'Configuration with ID \'201\' successfully migrated to stack \'dest-stack\'.',
+            $record['message']
         );
     }
 
@@ -563,58 +552,49 @@ class MigrateTest extends TestCase
 
         $migrate->run();
 
-        self::assertTrue(
-            $logsHandler->hasInfo('Migrating configurations with secrets'),
+        $records = array_filter(
+            $logsHandler->getRecords(),
+            fn(array $record) => in_array('secrets', $record['context'] ?? [], true)
         );
+        self::assertCount(8, $records);
 
-        self::assertTrue(
-            $logsHandler->hasInfo([
-                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
-                'context' => [
-                    'configId' => '101',
-                    'componentId' => 'keboola.wr-db-snowflake',
-                ],
-            ]),
+        $record = array_shift($records);
+        self::assertSame('Migrating configurations with secrets', $record['message']);
+        $record = array_shift($records);
+        self::assertSame(
+            'Migrating configuration "101" of component "keboola.wr-db-snowflake"',
+            $record['message']
         );
-        self::assertTrue(
-            $logsHandler->hasInfo('Configuration with ID \'101\' successfully migrated to stack \'dest-stack\'.'),
+        $record = array_shift($records);
+        self::assertSame(
+            'Configuration with ID \'101\' successfully migrated to stack \'dest-stack\'.',
+            $record['message']
         );
-
-        self::assertTrue(
-            $logsHandler->hasInfo([
-                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
-                'context' => [
-                    'configId' => '102',
-                    'componentId' => 'keboola.wr-db-snowflake',
-                ],
-            ]),
+        $record = array_shift($records);
+        self::assertSame(
+            'Migrating configuration "102" of component "keboola.wr-db-snowflake"',
+            $record['message']
         );
-        self::assertTrue(
-            $logsHandler->hasInfo('Configuration with ID \'102\' successfully migrated to stack \'dest-stack\'.'),
+        $record = array_shift($records);
+        self::assertSame(
+            'Configuration with ID \'102\' successfully migrated to stack \'dest-stack\'.',
+            $record['message']
         );
-
-        self::assertTrue(
-            $logsHandler->hasInfo([
-                'message' => 'Migrating configuration "{configId}" of component "{componentId}"',
-                'context' => [
-                    'configId' => '102',
-                    'componentId' => 'keboola.wr-db-snowflake',
-                ],
-            ]),
+        $record = array_shift($records);
+        self::assertSame(
+            'Migrating configuration "103" of component "keboola.wr-db-snowflake"',
+            $record['message']
         );
-        self::assertTrue(
-            $logsHandler->hasInfo([
-                'message' => 'Used existing Snowflake workspace "{workspace}" for configuration '
-                    . 'with ID "{configId}" ({componentId}).',
-                'context' => [
-                    'workspace' => 'USER_01',
-                    'configId' => '103',
-                    'componentId' => 'keboola.wr-db-snowflake',
-                ],
-            ]),
+        $record = array_shift($records);
+        self::assertSame(
+            'Used existing Snowflake workspace \'USER_01\' for configuration with ID \'103\' '
+            . '(keboola.wr-db-snowflake).',
+            $record['message']
         );
-        self::assertTrue(
-            $logsHandler->hasInfo('Configuration with ID \'103\' successfully migrated to stack \'dest-stack\'.'),
+        $record = array_shift($records);
+        self::assertSame(
+            'Configuration with ID \'103\' successfully migrated to stack \'dest-stack\'.',
+            $record['message']
         );
     }
 


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-2400

Catch error responses from `encryption-api` during configuration migration:
- allow the migration to continue even if an error occurs
- enhance error logs by including the config ID
