### PR TITLE
Ignore migration configs when checking for empty project

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -14,7 +14,11 @@ use Symfony\Component\Validator\Validation;
 
 class Utils
 {
-    private const IGNORED_COMPONENTS = ['keboola.app-project-migrate-large-tables', 'keboola.app-project-migrate'];
+    private const IGNORED_COMPONENTS = [
+        'keboola.app-project-migrate-large-tables',
+        'keboola.app-project-migrate',
+        'keboola.orchestrator',
+    ];
 
     public static function checkIfProjectEmpty(Client $client, Components $componentsClient): bool
     {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -14,11 +14,17 @@ use Symfony\Component\Validator\Validation;
 
 class Utils
 {
+    private const IGNORED_COMPONENTS = ['keboola.app-project-migrate-large-tables', 'keboola.app-project-migrate'];
+
     public static function checkIfProjectEmpty(Client $client, Components $componentsClient): bool
     {
         $listOfComponents = $componentsClient->listComponents();
         if (!empty($listOfComponents)) {
-            return false;
+            foreach ($listOfComponents as $component) {
+                if (!in_array($component['id'], self::IGNORED_COMPONENTS)) {
+                    return false;
+                }
+            }
         }
 
         $listOfBuckets = $client->listBuckets();

--- a/tests/phpunit/UtilsTest.php
+++ b/tests/phpunit/UtilsTest.php
@@ -108,6 +108,24 @@ class UtilsTest extends TestCase
                         ],
                     ],
                 ],
+                [
+                    'id' => 'keboola.orchestrator',
+                    'type' => 'app',
+                    'name' => 'Flow',
+                    'configurations' => [
+                        [
+                            'id' => '672381894',
+                            'created' => '2021-02-02T15:04:12+0100',
+                            'creatorToken' => [
+                                'id' => 157401,
+                                'description' => 'ondrej.jodas@keboola.com',
+                            ],
+                            'version' => 1,
+                            'changeDescription' => 'Configuration created',
+                            'isDeleted' => false,
+                        ],
+                    ],
+                ],
             ],
             [],
             true,

--- a/tests/phpunit/UtilsTest.php
+++ b/tests/phpunit/UtilsTest.php
@@ -48,28 +48,69 @@ class UtilsTest extends TestCase
         yield 'non-empty component configs' => [
             [
                 [
-                    [
-                        'id' => 'keboola.ex-db-mssql',
-                        'type' => 'extractor',
-                        'name' => 'Microsoft SQL Server',
-                        'configurations' => [
-                            [
-                                'id' => '672381894',
-                                'created' => '2021-02-02T15:04:12+0100',
-                                'creatorToken' => [
-                                    'id' => 157401,
-                                    'description' => 'ondrej.jodas@keboola.com',
-                                ],
-                                'version' => 1,
-                                'changeDescription' => 'Configuration created',
-                                'isDeleted' => false,
+                    'id' => 'keboola.ex-db-mssql',
+                    'type' => 'extractor',
+                    'name' => 'Microsoft SQL Server',
+                    'configurations' => [
+                        [
+                            'id' => '672381894',
+                            'created' => '2021-02-02T15:04:12+0100',
+                            'creatorToken' => [
+                                'id' => 157401,
+                                'description' => 'ondrej.jodas@keboola.com',
                             ],
+                            'version' => 1,
+                            'changeDescription' => 'Configuration created',
+                            'isDeleted' => false,
                         ],
                     ],
                 ],
             ],
             [],
             false,
+        ];
+
+        yield 'only contains migration configs' => [
+            [
+                [
+                    'id' => 'keboola.app-project-migrate-large-tables',
+                    'type' => 'app',
+                    'name' => 'Migration App',
+                    'configurations' => [
+                        [
+                            'id' => '672381894',
+                            'created' => '2021-02-02T15:04:12+0100',
+                            'creatorToken' => [
+                                'id' => 157401,
+                                'description' => 'ondrej.jodas@keboola.com',
+                            ],
+                            'version' => 1,
+                            'changeDescription' => 'Configuration created',
+                            'isDeleted' => false,
+                        ],
+                    ],
+                ],
+                [
+                    'id' => 'keboola.app-project-migrate',
+                    'type' => 'app',
+                    'name' => 'Migrate Tables App',
+                    'configurations' => [
+                        [
+                            'id' => '672381894',
+                            'created' => '2021-02-02T15:04:12+0100',
+                            'creatorToken' => [
+                                'id' => 157401,
+                                'description' => 'ondrej.jodas@keboola.com',
+                            ],
+                            'version' => 1,
+                            'changeDescription' => 'Configuration created',
+                            'isDeleted' => false,
+                        ],
+                    ],
+                ],
+            ],
+            [],
+            true,
         ];
 
         yield 'non-empty storage buckets' => [


### PR DESCRIPTION
This is so we can set up flows that run the structure only migration and then large tables configs with splitting up the tables into multiple configs