### PR TITLE
feat: Add Data Gateway migration support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+App Project Migrate is a Keboola Connection orchestration application that migrates projects between stacks (e.g., US to EU). It coordinates multiple specialized migration applications to transfer configurations, data, secrets, and infrastructure.
+
+The application runs in the **destination** project and reads from the **source** project (which remains unchanged).
+
+## Build & Test Commands
+
+```bash
+# Full build pipeline (lint → phpcs → phpstan → tests)
+composer build
+
+# Individual commands
+composer tests              # Run all tests (phpunit + datadir)
+composer tests-phpunit      # Unit tests only (tests/phpunit/)
+composer tests-datadir      # Functional tests only (tests/functional/)
+composer phpstan            # Static analysis (max level)
+composer phpcs              # Code style check
+composer phpcbf             # Auto-fix code style
+
+# Docker development
+docker-compose build
+docker-compose run --rm dev composer install --no-scripts
+docker-compose run --rm dev composer tests
+```
+
+## Architecture
+
+### Core Flow
+
+1. **Component** (`src/Component.php`) - Entry point, validates tokens and project state
+2. **Migrate** (`src/Migrate.php`) - Orchestrates migration steps in sequence
+3. **JobRunner** - Executes jobs via appropriate queue system (QueueV2 or legacy Syrup)
+4. **AfterMigration** (`src/Checker/AfterMigration.php`) - Post-migration validation
+
+### Migration Steps (in order)
+
+1. Backup source project (keboola.project-backup)
+2. Restore to destination (keboola.project-restore)
+3. Migrate secrets/configs via encryption-api (if enabled)
+4. Migrate table data directly (keboola.app-project-migrate-large-tables)
+5. Migrate Snowflake writers and Orchestrators (dedicated apps)
+
+### Key Patterns
+
+- **JobRunner Factory**: Creates QueueV2JobRunner or SyrupJobRunner based on project features
+- **Configuration**: ConfigDefinition uses Symfony Config for validation; secrets prefixed with `#`
+- **Data Modes**: `sapi` (API-based transfer) or `database` (direct DB replication)
+
+### Configuration Parameters
+
+Required: `sourceKbcUrl`, `#sourceKbcToken`
+Optional: `migrateSecrets`, `migrateBuckets`, `migrateTables`, `dryRun`, `dataMode`, etc.
+
+When `migrateSecrets=true`: requires `#sourceManageToken`
+When `dataMode=database`: requires `db` object with credentials
+
+## Code Standards
+
+- PHP 7.4 with strict types
+- PHPStan level max
+- Keboola coding standard (PSR-12 based)
+- UserException for user-actionable errors

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Migration steps performed by the application:
 - Migrate GoodData writers https://github.com/keboola/app-gooddata-writer-migrate
 - Migrate Snowflake writers https://github.com/keboola/app-snowflake-writer-migrate
 - Migrate Orchestrators https://github.com/keboola/app-orchestrator-migrate
+- Migrate Data Gateway configurations (creates new workspaces with keypair authentication)
 
 
 ## Usage
@@ -58,6 +59,7 @@ curl -X POST \
       "migrateBuckets": true,
       "migrateTables": true,
       "migrateProjectMetadata": true,
+      "migrateDataGateway": true,
       "skipRegionValidation": true,
       "checkEmptyProject": true,
       "isSourceByodb": false,
@@ -89,6 +91,7 @@ The request contains the following parameters:
 - `migrateProjectMetadata`: Enables migration of project metadata
 - `checkEmptyProject`: Check if the destination project is empty before migration
 - `skipRegionValidation`: Skips validation of regions during migration
+- `migrateDataGateway`: Enables migration of Data Gateway configurations (default: true). Creates new READER workspaces with keypair authentication. **Note:** Data from original workspaces is NOT migrated - users must load data manually.
 - `isSourceByodb`: Whether the source project is a BYODB project (default: false)
 - `sourceByodb`: Source BYODB identifier (required when `isSourceByodb` is true)
 - `includeWorkspaceSchemas`: Array of workspace schema names to include in migration (default: [])
@@ -135,6 +138,12 @@ What is **not** executed during dry-run mode?
   - [write data](https://github.com/keboola/app-project-migrate-tables-data/blob/88625047c4e6974fc556a2ff0eabdbfbf16b2c51/src/Strategy/SapiMigrate.php#L96) into destination tables
 - database mode:
   - [replicate tables](https://github.com/keboola/app-project-migrate-tables-data/blob/88625047c4e6974fc556a2ff0eabdbfbf16b2c51/src/Strategy/DatabaseMigrate.php#L109)
+
+#### Migrate Data Gateway
+
+- create new READER workspace with keypair authentication
+- update configuration with new workspace credentials
+- **Note:** Workspace data is NOT migrated
 
 ## Development
  

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "keboola/encryption-api-php-client": "^0.2.2",
         "keboola/job-queue-api-php-client": "^5.2",
         "keboola/php-component": "^11.0",
-        "keboola/storage-api-client": "^18.4",
+        "keboola/storage-api-client": "^18.6",
         "keboola/sync-actions-client": "^3.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e3d79b440822a4bedaa6f1bf78fb479a",
+    "content-hash": "4d063df7d16f0feca20edcb253c54e5c",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1340,65 +1340,17 @@
             "time": "2025-04-24T11:59:38+00:00"
         },
         {
-            "name": "keboola/php-datatypes",
-            "version": "8.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/keboola/php-datatypes.git",
-                "reference": "21d4d87f6439102b946a1ee45d83a59babff917d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/keboola/php-datatypes/zipball/21d4d87f6439102b946a1ee45d83a59babff917d",
-                "reference": "21d4d87f6439102b946a1ee45d83a59babff917d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.2"
-            },
-            "require-dev": {
-                "keboola/coding-standard": "^15",
-                "php-parallel-lint/php-parallel-lint": "^1.3",
-                "phpstan/phpdoc-parser": "^1.6",
-                "phpstan/phpstan": "^1.4",
-                "phpunit/phpunit": "^9",
-                "squizlabs/php_codesniffer": "^3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Keboola\\Datatype\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Keboola",
-                    "email": "devel@keboola.com"
-                }
-            ],
-            "description": "PHP datatypes for databases",
-            "support": {
-                "issues": "https://github.com/keboola/php-datatypes/issues",
-                "source": "https://github.com/keboola/php-datatypes/tree/8.2.0"
-            },
-            "time": "2025-08-27T11:12:26+00:00"
-        },
-        {
             "name": "keboola/storage-api-client",
-            "version": "v18.4.0",
+            "version": "v18.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/storage-api-php-client.git",
-                "reference": "acc47f2590acdce454f6455ef37459c42b76fd73"
+                "reference": "6202e156cf77d79f1a28334600bd63fdf931dc78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/storage-api-php-client/zipball/acc47f2590acdce454f6455ef37459c42b76fd73",
-                "reference": "acc47f2590acdce454f6455ef37459c42b76fd73",
+                "url": "https://api.github.com/repos/keboola/storage-api-php-client/zipball/6202e156cf77d79f1a28334600bd63fdf931dc78",
+                "reference": "6202e156cf77d79f1a28334600bd63fdf931dc78",
                 "shasum": ""
             },
             "require": {
@@ -1407,7 +1359,6 @@
                 "google/cloud-storage": "^1.27",
                 "guzzlehttp/guzzle": "~7.0",
                 "keboola/csv": "^1",
-                "keboola/php-datatypes": "^8.0",
                 "microsoft/azure-storage-blob": "^1.5",
                 "php": ">=8.2",
                 "psr/log": "^1.1|^2.0|^3.0",
@@ -1415,35 +1366,16 @@
                 "symfony/process": "^7.0||^6.0||^5.0||^4.0"
             },
             "require-dev": {
-                "brianium/paratest": "2.*|6.*",
-                "ext-bcmath": "*",
                 "ext-curl": "*",
-                "ext-pdo": "*",
-                "ext-pdo_pgsql": "*",
-                "flow-php/filesystem": "^0.21.0",
-                "flow-php/parquet": "^0.21.0",
-                "flow-php/types": "^0.21.0",
-                "google/cloud-bigquery-analyticshub": "^0.1.0",
-                "keboola/coding-standard": "^15.0",
-                "keboola/kbc-manage-api-php-client": "^9.0",
-                "keboola/php-csv-db-import": "^6",
-                "keboola/phpunit-retry-annotations": "^0.5",
-                "keboola/retry": "^0.5.0",
-                "keboola/table-backend-utils": ">=2.9.0",
-                "phpstan/phpstan": "^1",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^7.0|^8.0|^9.0",
-                "rector/rector": "^0.12.23",
-                "squizlabs/php_codesniffer": "^3",
-                "tomasfejfar/phpstan-phpunit": "^0.1.0"
+                "phpunit/phpunit": "^9.0|^10"
             },
             "type": "library",
             "autoload": {
                 "files": [
                     "src/Keboola/StorageApi/createSimpleJobPollDelay.php"
                 ],
-                "psr-0": {
-                    "Keboola\\StorageApi": "src/"
+                "psr-4": {
+                    "Keboola\\StorageApi\\": "src/Keboola/StorageApi/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1454,9 +1386,9 @@
             "homepage": "http://keboola.com",
             "support": {
                 "issues": "https://github.com/keboola/storage-api-php-client/issues",
-                "source": "https://github.com/keboola/storage-api-php-client/tree/v18.4.0"
+                "source": "https://github.com/keboola/storage-api-php-client/tree/v18.6.0"
             },
-            "time": "2025-09-03T07:01:18+00:00"
+            "time": "2026-01-06T10:21:05+00:00"
         },
         {
             "name": "keboola/sync-actions-client",
@@ -6231,5 +6163,5 @@
         "php": "^8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,6 +13,7 @@ class Config extends BaseConfig
     public const PROJECT_RESTORE_COMPONENT = 'keboola.project-restore';
     public const SNOWFLAKE_WRITER_MIGRATE_COMPONENT = 'keboola.app-snowflake-writer-migrate';
     public const DATA_OF_TABLES_MIGRATE_COMPONENT = 'keboola.app-project-migrate-large-tables';
+    public const DATA_GATEWAY_COMPONENT = 'keboola.app-data-gateway';
 
     public function getSourceProjectUrl(): string
     {
@@ -41,11 +42,9 @@ class Config extends BaseConfig
 
     public function getSourceManageToken(): ?string
     {
-        try {
-            return $this->getStringValue(['parameters', '#sourceManageToken']);
-        } catch (InvalidArgumentException) {
-            return null;
-        }
+        /** @var string|null $value */
+        $value = $this->getValue(['parameters', '#sourceManageToken']);
+        return is_string($value) ? $value : null;
     }
 
     public function getMigrateDataMode(): string
@@ -91,6 +90,11 @@ class Config extends BaseConfig
     public function shouldSkipRegionValidation(): bool
     {
         return $this->getBoolValue(['parameters', 'skipRegionValidation']);
+    }
+
+    public function shouldMigrateDataGateway(): bool
+    {
+        return $this->getBoolValue(['parameters', 'migrateDataGateway'], true);
     }
 
     public function shouldMigrateBuckets(): bool

--- a/src/ConfigDefinition.php
+++ b/src/ConfigDefinition.php
@@ -35,6 +35,7 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->booleanNode('migrateTables')->defaultTrue()->end()
                 ->booleanNode('migrateProjectMetadata')->defaultTrue()->end()
                 ->booleanNode('skipRegionValidation')->defaultFalse()->end()
+                ->booleanNode('migrateDataGateway')->defaultTrue()->end()
                 ->booleanNode('checkEmptyProject')->defaultTrue()->end()
                 ->enumNode('dataMode')->values(['sapi', 'database'])->defaultValue('sapi')->end()
                 ->booleanNode('isSourceByodb')->defaultFalse()->end()

--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\AppProjectMigrate;
 
 use Keboola\AppProjectMigrate\JobRunner\JobRunner;
+use Keboola\AppProjectMigrate\Migrator\DataGatewayMigrator;
 use Keboola\Component\UserException;
 use Keboola\EncryptionApiClient\Exception\ClientException as EncryptionClientException;
 use Keboola\EncryptionApiClient\Migrations as MigrationsClient;
@@ -71,6 +72,15 @@ class Migrate
                 // We want to migrate Snowflake writers only if we are not migrating secrets, because when migrating
                 // secrets, Snowflake writers will be migrated by the encryption-api.
                 $this->migrateSnowflakeWriters();
+            }
+
+            if ($this->config->shouldMigrateDataGateway()) {
+                $dataGatewayMigrator = new DataGatewayMigrator(
+                    $this->destProjectStorageClient,
+                    $this->logger,
+                    $this->config->isDryRun(),
+                );
+                $dataGatewayMigrator->migrate();
             }
         } catch (EncryptionClientException $e) {
             if ($e->getCode() >= 400 && $e->getCode() < 500) {

--- a/src/Migrator/DataGatewayMigrator.php
+++ b/src/Migrator/DataGatewayMigrator.php
@@ -6,47 +6,30 @@ namespace Keboola\AppProjectMigrate\Migrator;
 
 use Keboola\AppProjectMigrate\Config;
 use Keboola\Component\UserException;
-use Keboola\EncryptionApiClient\Encryption;
 use Keboola\StorageApi\Client as StorageClient;
 use Keboola\StorageApi\Components;
 use Keboola\StorageApi\Options\Components\Configuration;
 use Keboola\StorageApi\WorkspaceLoginType;
-use Keboola\StorageApi\Workspaces;
 use Psr\Log\LoggerInterface;
 
 class DataGatewayMigrator
 {
     /**
-     * @var array<int, array{
-     *     workspaceId: int,
-     *     host: string,
-     *     user: string,
-     *     schema: string,
-     *     warehouse: string,
-     *     database: string,
-     *     role: string|null,
-     *     encryptedPrivateKey: string
+     * Cache of migrated workspaces by source schema.
+     * When multiple configs share the same schema, they can reuse the same workspace.
+     *
+     * @var array<string, array{
+     *     id: int,
+     *     connection: array<string, mixed>
      * }>
      */
     private array $migratedWorkspaces = [];
-
-    private Encryption $encryptionClient;
-    private string $projectId;
 
     public function __construct(
         private readonly StorageClient $destStorageClient,
         private readonly LoggerInterface $logger,
         private readonly bool $dryRun = false,
-        ?Encryption $encryptionClient = null,
     ) {
-        /** @var array{owner: array{id: int}} $tokenInfo */
-        $tokenInfo = $this->destStorageClient->verifyToken();
-        $this->projectId = (string) $tokenInfo['owner']['id'];
-
-        $this->encryptionClient = $encryptionClient ?? new Encryption(
-            $this->destStorageClient->getTokenString(),
-            ['url' => $this->destStorageClient->getServiceUrl('encryption')],
-        );
     }
 
     public function migrate(): void
@@ -69,12 +52,10 @@ class DataGatewayMigrator
             return;
         }
 
-        $destWorkspaces = new Workspaces($this->destStorageClient);
-
         /** @var array<int, array{id: string}> $configurations */
         $configurations = $dataGatewayComponent['configurations'];
         foreach ($configurations as $config) {
-            $this->migrateConfiguration($config['id'], $destComponentsApi, $destWorkspaces);
+            $this->migrateConfiguration($config['id'], $destComponentsApi);
         }
 
         $this->logger->info('Data Gateway configurations migrated');
@@ -83,7 +64,6 @@ class DataGatewayMigrator
     private function migrateConfiguration(
         string $configId,
         Components $destComponentsApi,
-        Workspaces $destWorkspaces,
     ): void {
         if ($this->dryRun) {
             $this->logger->info(sprintf('[dry-run] Would migrate Data Gateway config "%s"', $configId));
@@ -92,55 +72,44 @@ class DataGatewayMigrator
 
         $this->logger->info(sprintf('Migrating Data Gateway config "%s"', $configId));
 
-        /** @var array{id: string, name: string, configuration: array{parameters?: array{db?: array{workspaceId?: int}}}} $configData */
+        /** @var array{id: string, name: string, configuration: array{parameters?: array{db?: array{schema?: string}}}} $configData */
         $configData = $destComponentsApi->getConfiguration(
             Config::DATA_GATEWAY_COMPONENT,
             $configId,
         );
 
-        $sourceWorkspaceId = $configData['configuration']['parameters']['db']['workspaceId'] ?? null;
+        $sourceSchema = $configData['configuration']['parameters']['db']['schema'] ?? null;
 
-        if ($sourceWorkspaceId !== null && isset($this->migratedWorkspaces[$sourceWorkspaceId])) {
+        // Check if we already migrated a workspace for this schema
+        if ($sourceSchema !== null && isset($this->migratedWorkspaces[$sourceSchema])) {
             $this->logger->info(sprintf(
                 'Reusing already migrated workspace %d for config "%s"',
-                $this->migratedWorkspaces[$sourceWorkspaceId]['workspaceId'],
+                $this->migratedWorkspaces[$sourceSchema]['id'],
                 $configId,
             ));
-            $this->updateConfigurationFromCache($configData, $sourceWorkspaceId, $destComponentsApi);
+            $this->updateConfiguration($configData, $this->migratedWorkspaces[$sourceSchema], $destComponentsApi);
             return;
         }
 
-        $keyPair = $this->generateKeyPair();
+        $publicKey = $this->generatePublicKey();
 
-        /** @var array{id: int, connection: array{host: string, user: string, schema: string, warehouse: string, database: string, role?: string|null}} $newWorkspace */
-        $newWorkspace = $destWorkspaces->createWorkspace([
-            'readOnlyStorageAccess' => true,
-            'backend' => 'snowflake',
-            'loginType' => WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR,
-            'publicKey' => $keyPair['publicKey'],
-        ]);
-
-        $encryptedPrivateKey = $this->encryptionClient->encryptPlainTextForConfiguration(
-            $keyPair['privateKey'],
-            $this->projectId,
+        /** @var array{id: int, connection: array<string, mixed>} $newWorkspace */
+        $newWorkspace = $destComponentsApi->createConfigurationWorkspace(
             Config::DATA_GATEWAY_COMPONENT,
             $configId,
+            [
+                'publicKey' => $publicKey,
+                'backend' => 'snowflake',
+                'loginType' => WorkspaceLoginType::SNOWFLAKE_PERSON_KEYPAIR,
+            ],
         );
 
-        if ($sourceWorkspaceId !== null) {
-            $this->migratedWorkspaces[$sourceWorkspaceId] = [
-                'workspaceId' => $newWorkspace['id'],
-                'host' => $newWorkspace['connection']['host'],
-                'user' => $newWorkspace['connection']['user'],
-                'schema' => $newWorkspace['connection']['schema'],
-                'warehouse' => $newWorkspace['connection']['warehouse'],
-                'database' => $newWorkspace['connection']['database'],
-                'role' => $newWorkspace['connection']['role'] ?? null,
-                'encryptedPrivateKey' => $encryptedPrivateKey,
-            ];
+        // Cache the workspace for potential reuse by other configs with same schema
+        if ($sourceSchema !== null) {
+            $this->migratedWorkspaces[$sourceSchema] = $newWorkspace;
         }
 
-        $this->updateConfiguration($configData, $newWorkspace, $encryptedPrivateKey, $destComponentsApi);
+        $this->updateConfiguration($configData, $newWorkspace, $destComponentsApi);
 
         $this->logger->info(sprintf(
             'Data Gateway config "%s" migrated to workspace %d',
@@ -160,72 +129,19 @@ class DataGatewayMigrator
      *     name: string,
      *     configuration: array{parameters?: array{db?: array<string, mixed>}}
      * } $configData
-     */
-    private function updateConfigurationFromCache(
-        array $configData,
-        int $sourceWorkspaceId,
-        Components $destComponentsApi,
-    ): void {
-        $cached = $this->migratedWorkspaces[$sourceWorkspaceId];
-
-        $oldDb = $this->removeEncryptedKeys($configData['configuration']['parameters']['db'] ?? []);
-        $configData['configuration']['parameters']['db'] = array_merge($oldDb, [
-            'host' => $cached['host'],
-            'user' => $cached['user'],
-            'schema' => $cached['schema'],
-            'warehouse' => $cached['warehouse'],
-            'database' => $cached['database'],
-            'workspaceId' => $cached['workspaceId'],
-            'role' => $cached['role'],
-            'loginType' => 'snowflake-service-keypair',
-            '#privateKey' => $cached['encryptedPrivateKey'],
-        ]);
-
-        $destComponentsApi->updateConfiguration(
-            (new Configuration())
-                ->setComponentId(Config::DATA_GATEWAY_COMPONENT)
-                ->setConfigurationId($configData['id'])
-                ->setName($configData['name'])
-                ->setConfiguration($configData['configuration']),
-        );
-    }
-
-    /**
-     * @param array{
-     *     id: string,
-     *     name: string,
-     *     configuration: array{parameters?: array{db?: array<string, mixed>}}
-     * } $configData
-     * @param array{
-     *     id: int,
-     *     connection: array{
-     *         host: string,
-     *         user: string,
-     *         schema: string,
-     *         warehouse: string,
-     *         database: string,
-     *         role?: string|null
-     *     }
-     * } $newWorkspace
+     * @param array{id: int, connection: array<string, mixed>} $workspace
      */
     private function updateConfiguration(
         array $configData,
-        array $newWorkspace,
-        string $encryptedPrivateKey,
+        array $workspace,
         Components $destComponentsApi,
     ): void {
         $oldDb = $this->removeEncryptedKeys($configData['configuration']['parameters']['db'] ?? []);
-        $configData['configuration']['parameters']['db'] = array_merge($oldDb, [
-            'host' => $newWorkspace['connection']['host'],
-            'user' => $newWorkspace['connection']['user'],
-            'schema' => $newWorkspace['connection']['schema'],
-            'warehouse' => $newWorkspace['connection']['warehouse'],
-            'database' => $newWorkspace['connection']['database'],
-            'workspaceId' => $newWorkspace['id'],
-            'role' => $newWorkspace['connection']['role'] ?? null,
-            'loginType' => 'snowflake-service-keypair',
-            '#privateKey' => $encryptedPrivateKey,
-        ]);
+        $configData['configuration']['parameters']['db'] = array_merge(
+            $oldDb,
+            $workspace['connection'],
+            ['workspaceId' => $workspace['id']],
+        );
 
         $destComponentsApi->updateConfiguration(
             (new Configuration())
@@ -254,34 +170,23 @@ class DataGatewayMigrator
         return $result;
     }
 
-    /**
-     * @return array{privateKey: string, publicKey: string}
-     */
-    private function generateKeyPair(): array
+    private function generatePublicKey(): string
     {
         $config = [
             'private_key_bits' => 2048,
             'private_key_type' => OPENSSL_KEYTYPE_RSA,
         ];
+
         $keyPair = openssl_pkey_new($config);
         if ($keyPair === false) {
             throw new UserException('Failed to generate RSA key pair');
         }
 
-        $privateKeyPem = null;
-        openssl_pkey_export($keyPair, $privateKeyPem);
-        if (!is_string($privateKeyPem)) {
-            throw new UserException('Failed to export private key');
-        }
-
         $details = openssl_pkey_get_details($keyPair);
         if ($details === false || !isset($details['key']) || !is_string($details['key'])) {
-            throw new UserException('Failed to get key pair details');
+            throw new UserException('Failed to get key details');
         }
 
-        return [
-            'privateKey' => $privateKeyPem,
-            'publicKey' => $details['key'],
-        ];
+        return $details['key'];
     }
 }

--- a/src/Migrator/DataGatewayMigrator.php
+++ b/src/Migrator/DataGatewayMigrator.php
@@ -37,12 +37,13 @@ class DataGatewayMigrator
         private readonly StorageClient $destStorageClient,
         private readonly LoggerInterface $logger,
         private readonly bool $dryRun = false,
+        ?Encryption $encryptionClient = null,
     ) {
         /** @var array{owner: array{id: int}} $tokenInfo */
         $tokenInfo = $this->destStorageClient->verifyToken();
         $this->projectId = (string) $tokenInfo['owner']['id'];
 
-        $this->encryptionClient = new Encryption(
+        $this->encryptionClient = $encryptionClient ?? new Encryption(
             $this->destStorageClient->getTokenString(),
             ['url' => $this->destStorageClient->getServiceUrl('encryption')],
         );

--- a/src/Migrator/DataGatewayMigrator.php
+++ b/src/Migrator/DataGatewayMigrator.php
@@ -99,6 +99,7 @@ class DataGatewayMigrator
             $configId,
             [
                 'publicKey' => $publicKey,
+                'useCase' => 'reader',
                 'backend' => 'snowflake',
                 'loginType' => WorkspaceLoginType::SNOWFLAKE_PERSON_KEYPAIR,
             ],

--- a/src/Migrator/DataGatewayMigrator.php
+++ b/src/Migrator/DataGatewayMigrator.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AppProjectMigrate\Migrator;
+
+use Keboola\AppProjectMigrate\Config;
+use Keboola\Component\UserException;
+use Keboola\EncryptionApiClient\Encryption;
+use Keboola\StorageApi\Client as StorageClient;
+use Keboola\StorageApi\Components;
+use Keboola\StorageApi\Options\Components\Configuration;
+use Keboola\StorageApi\WorkspaceLoginType;
+use Keboola\StorageApi\Workspaces;
+use Psr\Log\LoggerInterface;
+
+class DataGatewayMigrator
+{
+    /**
+     * @var array<int, array{
+     *     workspaceId: int,
+     *     host: string,
+     *     user: string,
+     *     schema: string,
+     *     warehouse: string,
+     *     database: string,
+     *     role: string|null,
+     *     encryptedPrivateKey: string
+     * }>
+     */
+    private array $migratedWorkspaces = [];
+
+    private Encryption $encryptionClient;
+    private string $projectId;
+
+    public function __construct(
+        private readonly StorageClient $destStorageClient,
+        private readonly LoggerInterface $logger,
+        private readonly bool $dryRun = false,
+    ) {
+        /** @var array{owner: array{id: int}} $tokenInfo */
+        $tokenInfo = $this->destStorageClient->verifyToken();
+        $this->projectId = (string) $tokenInfo['owner']['id'];
+
+        $this->encryptionClient = new Encryption(
+            $this->destStorageClient->getTokenString(),
+            ['url' => $this->destStorageClient->getServiceUrl('encryption')],
+        );
+    }
+
+    public function migrate(): void
+    {
+        $this->logger->info('Migrating Data Gateway configurations');
+
+        $destComponentsApi = new Components($this->destStorageClient);
+        $components = $destComponentsApi->listComponents();
+
+        $dataGatewayComponent = null;
+        foreach ($components as $component) {
+            if ($component['id'] === Config::DATA_GATEWAY_COMPONENT) {
+                $dataGatewayComponent = $component;
+                break;
+            }
+        }
+
+        if ($dataGatewayComponent === null || empty($dataGatewayComponent['configurations'])) {
+            $this->logger->info('No Data Gateway configurations found.');
+            return;
+        }
+
+        $destWorkspaces = new Workspaces($this->destStorageClient);
+
+        /** @var array<int, array{id: string}> $configurations */
+        $configurations = $dataGatewayComponent['configurations'];
+        foreach ($configurations as $config) {
+            $this->migrateConfiguration($config['id'], $destComponentsApi, $destWorkspaces);
+        }
+
+        $this->logger->info('Data Gateway configurations migrated');
+    }
+
+    private function migrateConfiguration(
+        string $configId,
+        Components $destComponentsApi,
+        Workspaces $destWorkspaces,
+    ): void {
+        if ($this->dryRun) {
+            $this->logger->info(sprintf('[dry-run] Would migrate Data Gateway config "%s"', $configId));
+            return;
+        }
+
+        $this->logger->info(sprintf('Migrating Data Gateway config "%s"', $configId));
+
+        /** @var array{id: string, name: string, configuration: array{parameters?: array{db?: array{workspaceId?: int}}}} $configData */
+        $configData = $destComponentsApi->getConfiguration(
+            Config::DATA_GATEWAY_COMPONENT,
+            $configId,
+        );
+
+        $sourceWorkspaceId = $configData['configuration']['parameters']['db']['workspaceId'] ?? null;
+
+        if ($sourceWorkspaceId !== null && isset($this->migratedWorkspaces[$sourceWorkspaceId])) {
+            $this->logger->info(sprintf(
+                'Reusing already migrated workspace %d for config "%s"',
+                $this->migratedWorkspaces[$sourceWorkspaceId]['workspaceId'],
+                $configId,
+            ));
+            $this->updateConfigurationFromCache($configData, $sourceWorkspaceId, $destComponentsApi);
+            return;
+        }
+
+        $keyPair = $this->generateKeyPair();
+
+        /** @var array{id: int, connection: array{host: string, user: string, schema: string, warehouse: string, database: string, role?: string|null}} $newWorkspace */
+        $newWorkspace = $destWorkspaces->createWorkspace([
+            'readOnlyStorageAccess' => true,
+            'backend' => 'snowflake',
+            'loginType' => WorkspaceLoginType::SNOWFLAKE_SERVICE_KEYPAIR,
+            'publicKey' => $keyPair['publicKey'],
+        ]);
+
+        $encryptedPrivateKey = $this->encryptionClient->encryptPlainTextForConfiguration(
+            $keyPair['privateKey'],
+            $this->projectId,
+            Config::DATA_GATEWAY_COMPONENT,
+            $configId,
+        );
+
+        if ($sourceWorkspaceId !== null) {
+            $this->migratedWorkspaces[$sourceWorkspaceId] = [
+                'workspaceId' => $newWorkspace['id'],
+                'host' => $newWorkspace['connection']['host'],
+                'user' => $newWorkspace['connection']['user'],
+                'schema' => $newWorkspace['connection']['schema'],
+                'warehouse' => $newWorkspace['connection']['warehouse'],
+                'database' => $newWorkspace['connection']['database'],
+                'role' => $newWorkspace['connection']['role'] ?? null,
+                'encryptedPrivateKey' => $encryptedPrivateKey,
+            ];
+        }
+
+        $this->updateConfiguration($configData, $newWorkspace, $encryptedPrivateKey, $destComponentsApi);
+
+        $this->logger->info(sprintf(
+            'Data Gateway config "%s" migrated to workspace %d',
+            $configId,
+            $newWorkspace['id'],
+        ));
+
+        $this->logger->warning(sprintf(
+            'Data Gateway workspace data NOT migrated for config "%s". User must load data manually.',
+            $configId,
+        ));
+    }
+
+    /**
+     * @param array{
+     *     id: string,
+     *     name: string,
+     *     configuration: array{parameters?: array{db?: array<string, mixed>}}
+     * } $configData
+     */
+    private function updateConfigurationFromCache(
+        array $configData,
+        int $sourceWorkspaceId,
+        Components $destComponentsApi,
+    ): void {
+        $cached = $this->migratedWorkspaces[$sourceWorkspaceId];
+
+        $oldDb = $this->removeEncryptedKeys($configData['configuration']['parameters']['db'] ?? []);
+        $configData['configuration']['parameters']['db'] = array_merge($oldDb, [
+            'host' => $cached['host'],
+            'user' => $cached['user'],
+            'schema' => $cached['schema'],
+            'warehouse' => $cached['warehouse'],
+            'database' => $cached['database'],
+            'workspaceId' => $cached['workspaceId'],
+            'role' => $cached['role'],
+            'loginType' => 'snowflake-service-keypair',
+            '#privateKey' => $cached['encryptedPrivateKey'],
+        ]);
+
+        $destComponentsApi->updateConfiguration(
+            (new Configuration())
+                ->setComponentId(Config::DATA_GATEWAY_COMPONENT)
+                ->setConfigurationId($configData['id'])
+                ->setName($configData['name'])
+                ->setConfiguration($configData['configuration']),
+        );
+    }
+
+    /**
+     * @param array{
+     *     id: string,
+     *     name: string,
+     *     configuration: array{parameters?: array{db?: array<string, mixed>}}
+     * } $configData
+     * @param array{
+     *     id: int,
+     *     connection: array{
+     *         host: string,
+     *         user: string,
+     *         schema: string,
+     *         warehouse: string,
+     *         database: string,
+     *         role?: string|null
+     *     }
+     * } $newWorkspace
+     */
+    private function updateConfiguration(
+        array $configData,
+        array $newWorkspace,
+        string $encryptedPrivateKey,
+        Components $destComponentsApi,
+    ): void {
+        $oldDb = $this->removeEncryptedKeys($configData['configuration']['parameters']['db'] ?? []);
+        $configData['configuration']['parameters']['db'] = array_merge($oldDb, [
+            'host' => $newWorkspace['connection']['host'],
+            'user' => $newWorkspace['connection']['user'],
+            'schema' => $newWorkspace['connection']['schema'],
+            'warehouse' => $newWorkspace['connection']['warehouse'],
+            'database' => $newWorkspace['connection']['database'],
+            'workspaceId' => $newWorkspace['id'],
+            'role' => $newWorkspace['connection']['role'] ?? null,
+            'loginType' => 'snowflake-service-keypair',
+            '#privateKey' => $encryptedPrivateKey,
+        ]);
+
+        $destComponentsApi->updateConfiguration(
+            (new Configuration())
+                ->setComponentId(Config::DATA_GATEWAY_COMPONENT)
+                ->setConfigurationId($configData['id'])
+                ->setName($configData['name'])
+                ->setConfiguration($configData['configuration']),
+        );
+    }
+
+    /**
+     * Remove all encrypted keys (starting with #) from the array to avoid mixing
+     * old encrypted values with new plain values.
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    private function removeEncryptedKeys(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            if (!str_starts_with($key, '#')) {
+                $result[$key] = $value;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @return array{privateKey: string, publicKey: string}
+     */
+    private function generateKeyPair(): array
+    {
+        $config = [
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ];
+        $keyPair = openssl_pkey_new($config);
+        if ($keyPair === false) {
+            throw new UserException('Failed to generate RSA key pair');
+        }
+
+        $privateKeyPem = null;
+        openssl_pkey_export($keyPair, $privateKeyPem);
+        if (!is_string($privateKeyPem)) {
+            throw new UserException('Failed to export private key');
+        }
+
+        $details = openssl_pkey_get_details($keyPair);
+        if ($details === false || !isset($details['key']) || !is_string($details['key'])) {
+            throw new UserException('Failed to get key pair details');
+        }
+
+        return [
+            'privateKey' => $privateKeyPem,
+            'publicKey' => $details['key'],
+        ];
+    }
+}

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -504,8 +504,6 @@ class ConfigTest extends TestCase
 
     public function testGetSourceManageTokenDefaultValue(): void
     {
-        $this->expectException(TypeError::class);
-
         $config = new Config(
             [
                 'parameters' => [
@@ -516,9 +514,7 @@ class ConfigTest extends TestCase
             new ConfigDefinition(),
         );
 
-        // getSourceManageToken catches InvalidArgumentException, but getStringValue throws TypeError
-        // when value is null (from defaultNull()). This is a known limitation.
-        $config->getSourceManageToken();
+        self::assertNull($config->getSourceManageToken());
     }
 
     /**

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -679,9 +679,6 @@ class MigrateTest extends TestCase
                 return current(array_filter($testConfigurations, fn ($c) => $c['id'] === $configId)) ?: null;
             })
         ;
-        $destClientMock->method('verifyToken')->willReturn(['owner' => ['id' => 123]]);
-        $destClientMock->method('getTokenString')->willReturn('test-token');
-        $destClientMock->method('getServiceUrl')->willReturn('https://encryption.keboola.com');
 
         /** @var Migrations&MockObject $migrationsClientMock */
         $migrationsClientMock = $this->createMock(Migrations::class);
@@ -1097,9 +1094,6 @@ class MigrateTest extends TestCase
                 return current(array_filter($testConfigurations, fn ($c) => $c['id'] === $configId)) ?: null;
             })
         ;
-        $destClientMock->method('verifyToken')->willReturn(['owner' => ['id' => 123]]);
-        $destClientMock->method('getTokenString')->willReturn('test-token');
-        $destClientMock->method('getServiceUrl')->willReturn('https://encryption.keboola.com');
 
         /** @var Migrations&MockObject $migrationsClientMock */
         $migrationsClientMock = $this->createMock(Migrations::class);
@@ -2274,18 +2268,6 @@ class MigrateTest extends TestCase
                 }
                 return null;
             });
-        // Mock verifyToken for DataGatewayMigrator
-        $destClientMock
-            ->method('verifyToken')
-            ->willReturn(['owner' => ['id' => 123]]);
-        // Mock getTokenString for DataGatewayMigrator
-        $destClientMock
-            ->method('getTokenString')
-            ->willReturn('test-token');
-        // Mock getServiceUrl for DataGatewayMigrator
-        $destClientMock
-            ->method('getServiceUrl')
-            ->willReturn('https://encryption.keboola.com');
         return $destClientMock;
     }
 }

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -261,8 +261,7 @@ class MigrateTest extends TestCase
             ->willReturn('123')
         ;
 
-        /** @var StorageClient&MockObject $destClientMock */
-        $destClientMock = $this->createMock(StorageClient::class);
+        $destClientMock = $this->createDestClientMock();
 
         /** @var Migrations&MockObject $migrationsClientMock */
         $migrationsClientMock = $this->createMock(Migrations::class);
@@ -411,8 +410,7 @@ class MigrateTest extends TestCase
             ->willReturn('123')
         ;
 
-        /** @var StorageClient&MockObject $destClientMock */
-        $destClientMock = $this->createMock(StorageClient::class);
+        $destClientMock = $this->createDestClientMock();
 
         /** @var Migrations&MockObject $migrationsClientMock */
         $migrationsClientMock = $this->createMock(Migrations::class);
@@ -672,6 +670,10 @@ class MigrateTest extends TestCase
             ->method('apiGet')
             ->willReturnCallback(function ($url) use ($testConfigurations): ?array {
                 /** @var string $url */
+                // Return empty array for components endpoint (used by DataGatewayMigrator)
+                if (str_starts_with($url, 'components?') || str_starts_with($url, 'branch/default/components?')) {
+                    return [];
+                }
                 preg_match('~components/([^/]+)/configs/([^/]+)~', $url, $matches);
                 [, , $configId] = $matches + [null, null, null];
                 return current(array_filter($testConfigurations, fn ($c) => $c['id'] === $configId)) ?: null;
@@ -884,7 +886,7 @@ class MigrateTest extends TestCase
             ->willReturn('https://encryption.keboola.com')
         ;
 
-        $destClientMock = $this->createMock(StorageClient::class);
+        $destClientMock = $this->createDestClientMock();
 
         $encryptionApiException = new EncryptionClientException('Something went wrong');
 
@@ -1083,6 +1085,10 @@ class MigrateTest extends TestCase
             ->method('apiGet')
             ->willReturnCallback(function ($url) use ($testConfigurations): ?array {
                 /** @var string $url */
+                // Return empty array for components endpoint (used by DataGatewayMigrator)
+                if (str_starts_with($url, 'components?') || str_starts_with($url, 'branch/default/components?')) {
+                    return [];
+                }
                 preg_match('~components/([^/]+)/configs/([^/]+)~', $url, $matches);
                 [, , $configId] = $matches + [null, null, null];
                 return current(array_filter($testConfigurations, fn ($c) => $c['id'] === $configId)) ?: null;
@@ -1168,7 +1174,7 @@ class MigrateTest extends TestCase
         $sourceJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
         $destJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
         $sourceClientMock = $this->createMock(StorageClient::class);
-        $destClientMock = $this->createMock(StorageClient::class);
+        $destClientMock = $this->createDestClientMock();
         $migrationsClientMock = $this->createMock(Migrations::class);
 
         // generate credentials
@@ -1226,7 +1232,7 @@ class MigrateTest extends TestCase
         $sourceJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
         $destJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
         $sourceClientMock = $this->createMock(StorageClient::class);
-        $destClientMock = $this->createMock(StorageClient::class);
+        $destClientMock = $this->createDestClientMock();
         $migrationsClientMock = $this->createMock(Migrations::class);
 
         $this->mockAddMethodGenerateS3ReadCredentials($sourceJobRunnerMock);
@@ -1463,7 +1469,7 @@ class MigrateTest extends TestCase
                 ],
             ]);
 
-        $destClientMock = $this->createMock(StorageClient::class);
+        $destClientMock = $this->createDestClientMock();
 
         $migrationsClientMock = $this->createMock(Migrations::class);
         $migrationsClientMock
@@ -1769,8 +1775,7 @@ class MigrateTest extends TestCase
         $sourceClientMock->method('apiGet')->willReturn([]);
         $sourceClientMock->method('getServiceUrl')->willReturn('https://encryption.keboola.com');
 
-        /** @var StorageClient&MockObject $destClientMock */
-        $destClientMock = $this->createMock(StorageClient::class);
+        $destClientMock = $this->createDestClientMock();
         /** @var Migrations&MockObject $migrationsClientMock */
         $migrationsClientMock = $this->createMock(Migrations::class);
 
@@ -1787,6 +1792,107 @@ class MigrateTest extends TestCase
         );
 
         $migrate->run();
+    }
+
+    public function testMigrateDataGatewayDisabled(): void
+    {
+        /** @var JobRunner&MockObject $sourceJobRunnerMock */
+        $sourceJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
+        /** @var JobRunner&MockObject $destJobRunnerMock */
+        $destJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
+
+        $this->mockAddMethodGenerateAbsReadCredentials($sourceJobRunnerMock);
+        $this->mockAddMethodBackupProject(
+            $sourceJobRunnerMock,
+            [
+                'id' => '222',
+                'status' => 'success',
+            ],
+            false,
+        );
+
+        $destJobRunnerMock->method('runJob')
+            ->willReturn(Job::fromApiResponse([
+                'id' => '222',
+                'runId' => 'run-123',
+                'parentRunId' => 'parent-123',
+                'project' => ['id' => '123'],
+                'token' => ['id' => 'token-123', 'description' => null],
+                'status' => 'success',
+                'desiredStatus' => 'processing',
+                'mode' => 'run',
+                'component' => 'test-component',
+                'config' => null,
+                'configData' => null,
+                'configRowIds' => null,
+                'tag' => null,
+                'createdTime' => '2024-01-01T00:00:00+00:00',
+                'startTime' => '2024-01-01T00:00:00+00:00',
+                'endTime' => '2024-01-01T00:00:00+00:00',
+                'durationSeconds' => null,
+                'result' => null,
+                'usageData' => null,
+                'isFinished' => true,
+                'url' => 'https://example.com',
+                'branchId' => null,
+                'variableValuesId' => null,
+                'variableValuesData' => [],
+                'backend' => [],
+                'executor' => null,
+                'metrics' => null,
+                'behavior' => [],
+                'parallelism' => null,
+                'type' => 'container',
+                'orchestrationJobId' => null,
+                'orchestrationTaskId' => null,
+                'onlyOrchestrationTaskIds' => null,
+                'previousJobId' => null,
+            ]));
+
+        $config = new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => 'https://connection.keboola.com',
+                    '#sourceKbcToken' => 'token',
+                    'migrateDataGateway' => false,
+                    'directDataMigration' => false,
+                ],
+            ],
+            new ConfigDefinition(),
+        );
+
+        $logsHandler = new TestHandler();
+        $logger = new Logger('tests', [$logsHandler]);
+
+        /** @var StorageClient&MockObject $sourceClientMock */
+        $sourceClientMock = $this->createMock(StorageClient::class);
+        $sourceClientMock->method('generateId')->willReturn('123');
+
+        $destClientMock = $this->createDestClientMock();
+
+        /** @var Migrations&MockObject $migrationsClientMock */
+        $migrationsClientMock = $this->createMock(Migrations::class);
+
+        $migrate = new Migrate(
+            $config,
+            $sourceJobRunnerMock,
+            $destJobRunnerMock,
+            $sourceClientMock,
+            $destClientMock,
+            $migrationsClientMock,
+            'https://dest-stack/',
+            'dest-token',
+            $logger,
+        );
+
+        $migrate->run();
+
+        // Verify that Data Gateway migration was NOT called
+        $dataGatewayLogs = array_filter(
+            $logsHandler->getRecords(),
+            fn(LogRecord $record) => str_contains($record->message, 'Data Gateway'),
+        );
+        self::assertCount(0, $dataGatewayLogs, 'Data Gateway migration should not be called');
     }
 
     public function successMigrateDataProvider(): Generator
@@ -2144,5 +2250,24 @@ class MigrateTest extends TestCase
         $result = json_decode($json, false);
         assert($result instanceof stdClass);
         return $result;
+    }
+
+    /**
+     * @return StorageClient&MockObject
+     */
+    private function createDestClientMock(): StorageClient
+    {
+        /** @var StorageClient&MockObject $destClientMock */
+        $destClientMock = $this->createMock(StorageClient::class);
+        $destClientMock
+            ->method('apiGet')
+            ->willReturnCallback(function (string $url) {
+                // Return empty array for components endpoint (used by DataGatewayMigrator)
+                if (str_starts_with($url, 'components?') || str_starts_with($url, 'branch/default/components?')) {
+                    return [];
+                }
+                return null;
+            });
+        return $destClientMock;
     }
 }

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -679,6 +679,9 @@ class MigrateTest extends TestCase
                 return current(array_filter($testConfigurations, fn ($c) => $c['id'] === $configId)) ?: null;
             })
         ;
+        $destClientMock->method('verifyToken')->willReturn(['owner' => ['id' => 123]]);
+        $destClientMock->method('getTokenString')->willReturn('test-token');
+        $destClientMock->method('getServiceUrl')->willReturn('https://encryption.keboola.com');
 
         /** @var Migrations&MockObject $migrationsClientMock */
         $migrationsClientMock = $this->createMock(Migrations::class);
@@ -1094,6 +1097,9 @@ class MigrateTest extends TestCase
                 return current(array_filter($testConfigurations, fn ($c) => $c['id'] === $configId)) ?: null;
             })
         ;
+        $destClientMock->method('verifyToken')->willReturn(['owner' => ['id' => 123]]);
+        $destClientMock->method('getTokenString')->willReturn('test-token');
+        $destClientMock->method('getServiceUrl')->willReturn('https://encryption.keboola.com');
 
         /** @var Migrations&MockObject $migrationsClientMock */
         $migrationsClientMock = $this->createMock(Migrations::class);
@@ -2268,6 +2274,18 @@ class MigrateTest extends TestCase
                 }
                 return null;
             });
+        // Mock verifyToken for DataGatewayMigrator
+        $destClientMock
+            ->method('verifyToken')
+            ->willReturn(['owner' => ['id' => 123]]);
+        // Mock getTokenString for DataGatewayMigrator
+        $destClientMock
+            ->method('getTokenString')
+            ->willReturn('test-token');
+        // Mock getServiceUrl for DataGatewayMigrator
+        $destClientMock
+            ->method('getServiceUrl')
+            ->willReturn('https://encryption.keboola.com');
         return $destClientMock;
     }
 }

--- a/tests/phpunit/Migrator/DataGatewayMigratorTest.php
+++ b/tests/phpunit/Migrator/DataGatewayMigratorTest.php
@@ -6,7 +6,6 @@ namespace Keboola\AppProjectMigrate\Tests\Migrator;
 
 use Keboola\AppProjectMigrate\Config;
 use Keboola\AppProjectMigrate\Migrator\DataGatewayMigrator;
-use Keboola\EncryptionApiClient\Encryption;
 use Keboola\StorageApi\Client as StorageClient;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -25,21 +24,7 @@ class DataGatewayMigratorTest extends TestCase
         /** @var StorageClient&MockObject $storageClientMock */
         $storageClientMock = $this->createMock(StorageClient::class);
         $storageClientMock->method('apiGet')->willReturnCallback($apiGetCallback);
-        $storageClientMock->method('verifyToken')->willReturn(['owner' => ['id' => 123]]);
         return $storageClientMock;
-    }
-
-    /**
-     * @return Encryption&MockObject
-     */
-    private function createEncryptionClientMock(): Encryption
-    {
-        /** @var Encryption&MockObject $encryptionClientMock */
-        $encryptionClientMock = $this->createMock(Encryption::class);
-        $encryptionClientMock
-            ->method('encryptPlainTextForConfiguration')
-            ->willReturn('KBC::SecureKV::encrypted-private-key');
-        return $encryptionClientMock;
     }
 
     public function testNoDataGatewayConfigurations(): void
@@ -54,12 +39,7 @@ class DataGatewayMigratorTest extends TestCase
             return [];
         });
 
-        $migrator = new DataGatewayMigrator(
-            $storageClientMock,
-            $logger,
-            false,
-            $this->createEncryptionClientMock(),
-        );
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
         $migrator->migrate();
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
@@ -84,12 +64,7 @@ class DataGatewayMigratorTest extends TestCase
             return [];
         });
 
-        $migrator = new DataGatewayMigrator(
-            $storageClientMock,
-            $logger,
-            false,
-            $this->createEncryptionClientMock(),
-        );
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
         $migrator->migrate();
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
@@ -119,12 +94,7 @@ class DataGatewayMigratorTest extends TestCase
         // In dry-run mode, no workspace should be created
         $storageClientMock->expects(self::never())->method('apiPostJson');
 
-        $migrator = new DataGatewayMigrator(
-            $storageClientMock,
-            $logger,
-            true,
-            $this->createEncryptionClientMock(),
-        );
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger, true);
         $migrator->migrate();
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
@@ -144,7 +114,7 @@ class DataGatewayMigratorTest extends TestCase
             'configuration' => [
                 'parameters' => [
                     'db' => [
-                        'workspaceId' => 100,
+                        'schema' => 'OLD_SCHEMA',
                         'host' => 'old-host.snowflake.com',
                         'user' => 'OLD_USER',
                     ],
@@ -187,7 +157,8 @@ class DataGatewayMigratorTest extends TestCase
             ->method('apiPostJson')
             ->willReturnCallback(
                 function (string $url) use ($newWorkspaceData): array {
-                    if ($url === 'workspaces') {
+                    // createConfigurationWorkspace uses apiPostJson
+                    if (str_contains($url, 'workspaces')) {
                         return $newWorkspaceData;
                     }
                     return [];
@@ -203,12 +174,7 @@ class DataGatewayMigratorTest extends TestCase
                 return [];
             });
 
-        $migrator = new DataGatewayMigrator(
-            $storageClientMock,
-            $logger,
-            false,
-            $this->createEncryptionClientMock(),
-        );
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
         $migrator->migrate();
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
@@ -230,26 +196,21 @@ class DataGatewayMigratorTest extends TestCase
         self::assertSame('NEW_WAREHOUSE', $db['warehouse']);
         self::assertSame('NEW_DATABASE', $db['database']);
         self::assertSame(200, $db['workspaceId']);
-        self::assertSame('snowflake-service-keypair', $db['loginType']);
-        self::assertArrayHasKey('#privateKey', $db);
-        self::assertIsString($db['#privateKey']);
-        // The key should be encrypted now
-        self::assertStringStartsWith('KBC::', $db['#privateKey']);
     }
 
-    public function testMigrateMultipleConfigurationsWithSharedWorkspace(): void
+    public function testMigrateMultipleConfigurationsWithSharedSchema(): void
     {
         $logsHandler = new TestHandler();
         $logger = new Logger('tests', [$logsHandler]);
 
-        $sharedWorkspaceId = 100;
+        $sharedSchema = 'SHARED_SCHEMA';
 
         $configData1 = [
             'id' => 'config-1',
             'name' => 'Data Gateway 1',
             'configuration' => [
                 'parameters' => [
-                    'db' => ['workspaceId' => $sharedWorkspaceId],
+                    'db' => ['schema' => $sharedSchema],
                 ],
             ],
         ];
@@ -259,7 +220,7 @@ class DataGatewayMigratorTest extends TestCase
             'name' => 'Data Gateway 2',
             'configuration' => [
                 'parameters' => [
-                    'db' => ['workspaceId' => $sharedWorkspaceId], // Same workspace
+                    'db' => ['schema' => $sharedSchema], // Same schema
                 ],
             ],
         ];
@@ -304,7 +265,7 @@ class DataGatewayMigratorTest extends TestCase
         $storageClientMock
             ->method('apiPostJson')
             ->willReturnCallback(function (string $url) use ($newWorkspaceData, &$workspaceCreateCount): array {
-                if ($url === 'workspaces') {
+                if (str_contains($url, 'workspaces')) {
                     $workspaceCreateCount++;
                     return $newWorkspaceData;
                 }
@@ -313,15 +274,10 @@ class DataGatewayMigratorTest extends TestCase
 
         $storageClientMock->method('apiPutJson')->willReturn([]);
 
-        $migrator = new DataGatewayMigrator(
-            $storageClientMock,
-            $logger,
-            false,
-            $this->createEncryptionClientMock(),
-        );
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
         $migrator->migrate();
 
-        // Only one workspace should be created (second config reuses the first)
+        // Only one workspace should be created (second config reuses the first by schema)
         self::assertSame(1, $workspaceCreateCount);
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
@@ -329,19 +285,19 @@ class DataGatewayMigratorTest extends TestCase
         self::assertContains('Reusing already migrated workspace 200 for config "config-2"', $messages);
     }
 
-    public function testMigrateConfigurationWithoutWorkspaceId(): void
+    public function testMigrateConfigurationWithoutSchema(): void
     {
         $logsHandler = new TestHandler();
         $logger = new Logger('tests', [$logsHandler]);
 
         $configData = [
             'id' => 'config-1',
-            'name' => 'Data Gateway without workspace',
+            'name' => 'Data Gateway without schema',
             'configuration' => [
                 'parameters' => [
                     'db' => [
                         'host' => 'some-host.snowflake.com',
-                        // No workspaceId
+                        // No schema
                     ],
                 ],
             ],
@@ -379,7 +335,7 @@ class DataGatewayMigratorTest extends TestCase
         $storageClientMock
             ->method('apiPostJson')
             ->willReturnCallback(function (string $url) use ($newWorkspaceData): array {
-                if ($url === 'workspaces') {
+                if (str_contains($url, 'workspaces')) {
                     return $newWorkspaceData;
                 }
                 return [];
@@ -387,12 +343,7 @@ class DataGatewayMigratorTest extends TestCase
 
         $storageClientMock->method('apiPutJson')->willReturn([]);
 
-        $migrator = new DataGatewayMigrator(
-            $storageClientMock,
-            $logger,
-            false,
-            $this->createEncryptionClientMock(),
-        );
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
         $migrator->migrate();
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
@@ -400,7 +351,7 @@ class DataGatewayMigratorTest extends TestCase
         self::assertContains('Data Gateway config "config-1" migrated to workspace 200', $messages);
     }
 
-    public function testMigrateMultipleConfigurationsWithDifferentWorkspaces(): void
+    public function testMigrateMultipleConfigurationsWithDifferentSchemas(): void
     {
         $logsHandler = new TestHandler();
         $logger = new Logger('tests', [$logsHandler]);
@@ -410,7 +361,7 @@ class DataGatewayMigratorTest extends TestCase
             'name' => 'Data Gateway 1',
             'configuration' => [
                 'parameters' => [
-                    'db' => ['workspaceId' => 100],
+                    'db' => ['schema' => 'SCHEMA_1'],
                 ],
             ],
         ];
@@ -420,7 +371,7 @@ class DataGatewayMigratorTest extends TestCase
             'name' => 'Data Gateway 2',
             'configuration' => [
                 'parameters' => [
-                    'db' => ['workspaceId' => 101], // Different workspace
+                    'db' => ['schema' => 'SCHEMA_2'], // Different schema
                 ],
             ],
         ];
@@ -453,7 +404,7 @@ class DataGatewayMigratorTest extends TestCase
         $storageClientMock
             ->method('apiPostJson')
             ->willReturnCallback(function (string $url) use (&$workspaceCreateCount): array {
-                if ($url === 'workspaces') {
+                if (str_contains($url, 'workspaces')) {
                     $workspaceCreateCount++;
                     return [
                         'id' => 200 + $workspaceCreateCount,
@@ -472,15 +423,10 @@ class DataGatewayMigratorTest extends TestCase
 
         $storageClientMock->method('apiPutJson')->willReturn([]);
 
-        $migrator = new DataGatewayMigrator(
-            $storageClientMock,
-            $logger,
-            false,
-            $this->createEncryptionClientMock(),
-        );
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
         $migrator->migrate();
 
-        // Two workspaces should be created (different source workspaceIds)
+        // Two workspaces should be created (different schemas)
         self::assertSame(2, $workspaceCreateCount);
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());

--- a/tests/phpunit/Migrator/DataGatewayMigratorTest.php
+++ b/tests/phpunit/Migrator/DataGatewayMigratorTest.php
@@ -6,6 +6,7 @@ namespace Keboola\AppProjectMigrate\Tests\Migrator;
 
 use Keboola\AppProjectMigrate\Config;
 use Keboola\AppProjectMigrate\Migrator\DataGatewayMigrator;
+use Keboola\EncryptionApiClient\Encryption;
 use Keboola\StorageApi\Client as StorageClient;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -15,23 +16,50 @@ use PHPUnit\Framework\TestCase;
 
 class DataGatewayMigratorTest extends TestCase
 {
+    /**
+     * @param callable(string): array $apiGetCallback
+     * @return StorageClient&MockObject
+     */
+    private function createStorageClientMock(callable $apiGetCallback): StorageClient
+    {
+        /** @var StorageClient&MockObject $storageClientMock */
+        $storageClientMock = $this->createMock(StorageClient::class);
+        $storageClientMock->method('apiGet')->willReturnCallback($apiGetCallback);
+        $storageClientMock->method('verifyToken')->willReturn(['owner' => ['id' => 123]]);
+        return $storageClientMock;
+    }
+
+    /**
+     * @return Encryption&MockObject
+     */
+    private function createEncryptionClientMock(): Encryption
+    {
+        /** @var Encryption&MockObject $encryptionClientMock */
+        $encryptionClientMock = $this->createMock(Encryption::class);
+        $encryptionClientMock
+            ->method('encryptPlainTextForConfiguration')
+            ->willReturn('KBC::SecureKV::encrypted-private-key');
+        return $encryptionClientMock;
+    }
+
     public function testNoDataGatewayConfigurations(): void
     {
         $logsHandler = new TestHandler();
         $logger = new Logger('tests', [$logsHandler]);
 
-        /** @var StorageClient&MockObject $storageClientMock */
-        $storageClientMock = $this->createMock(StorageClient::class);
-        $storageClientMock
-            ->method('apiGet')
-            ->willReturnCallback(function (string $url): array {
-                if (str_contains($url, 'components?')) {
-                    return []; // No components
-                }
-                return [];
-            });
+        $storageClientMock = $this->createStorageClientMock(function (string $url): array {
+            if (str_contains($url, 'components?')) {
+                return []; // No components
+            }
+            return [];
+        });
 
-        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator = new DataGatewayMigrator(
+            $storageClientMock,
+            $logger,
+            false,
+            $this->createEncryptionClientMock(),
+        );
         $migrator->migrate();
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
@@ -44,23 +72,24 @@ class DataGatewayMigratorTest extends TestCase
         $logsHandler = new TestHandler();
         $logger = new Logger('tests', [$logsHandler]);
 
-        /** @var StorageClient&MockObject $storageClientMock */
-        $storageClientMock = $this->createMock(StorageClient::class);
-        $storageClientMock
-            ->method('apiGet')
-            ->willReturnCallback(function (string $url): array {
-                if (str_contains($url, 'components?')) {
-                    return [
-                        [
-                            'id' => Config::DATA_GATEWAY_COMPONENT,
-                            'configurations' => [], // Empty configurations
-                        ],
-                    ];
-                }
-                return [];
-            });
+        $storageClientMock = $this->createStorageClientMock(function (string $url): array {
+            if (str_contains($url, 'components?')) {
+                return [
+                    [
+                        'id' => Config::DATA_GATEWAY_COMPONENT,
+                        'configurations' => [], // Empty configurations
+                    ],
+                ];
+            }
+            return [];
+        });
 
-        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator = new DataGatewayMigrator(
+            $storageClientMock,
+            $logger,
+            false,
+            $this->createEncryptionClientMock(),
+        );
         $migrator->migrate();
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
@@ -72,29 +101,30 @@ class DataGatewayMigratorTest extends TestCase
         $logsHandler = new TestHandler();
         $logger = new Logger('tests', [$logsHandler]);
 
-        /** @var StorageClient&MockObject $storageClientMock */
-        $storageClientMock = $this->createMock(StorageClient::class);
-        $storageClientMock
-            ->method('apiGet')
-            ->willReturnCallback(function (string $url): array {
-                if (str_contains($url, 'components?')) {
-                    return [
-                        [
-                            'id' => Config::DATA_GATEWAY_COMPONENT,
-                            'configurations' => [
-                                ['id' => 'config-1'],
-                                ['id' => 'config-2'],
-                            ],
+        $storageClientMock = $this->createStorageClientMock(function (string $url): array {
+            if (str_contains($url, 'components?')) {
+                return [
+                    [
+                        'id' => Config::DATA_GATEWAY_COMPONENT,
+                        'configurations' => [
+                            ['id' => 'config-1'],
+                            ['id' => 'config-2'],
                         ],
-                    ];
-                }
-                return [];
-            });
+                    ],
+                ];
+            }
+            return [];
+        });
 
         // In dry-run mode, no workspace should be created
         $storageClientMock->expects(self::never())->method('apiPostJson');
 
-        $migrator = new DataGatewayMigrator($storageClientMock, $logger, dryRun: true);
+        $migrator = new DataGatewayMigrator(
+            $storageClientMock,
+            $logger,
+            true,
+            $this->createEncryptionClientMock(),
+        );
         $migrator->migrate();
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
@@ -136,26 +166,22 @@ class DataGatewayMigratorTest extends TestCase
 
         $updatedConfiguration = null;
 
-        /** @var StorageClient&MockObject $storageClientMock */
-        $storageClientMock = $this->createMock(StorageClient::class);
-        $storageClientMock
-            ->method('apiGet')
-            ->willReturnCallback(function (string $url) use ($configData): array {
-                if (str_contains($url, 'components?')) {
-                    return [
-                        [
-                            'id' => Config::DATA_GATEWAY_COMPONENT,
-                            'configurations' => [
-                                ['id' => 'config-1'],
-                            ],
+        $storageClientMock = $this->createStorageClientMock(function (string $url) use ($configData): array {
+            if (str_contains($url, 'components?')) {
+                return [
+                    [
+                        'id' => Config::DATA_GATEWAY_COMPONENT,
+                        'configurations' => [
+                            ['id' => 'config-1'],
                         ],
-                    ];
-                }
-                if (str_contains($url, 'configs/config-1')) {
-                    return $configData;
-                }
-                return [];
-            });
+                    ],
+                ];
+            }
+            if (str_contains($url, 'configs/config-1')) {
+                return $configData;
+            }
+            return [];
+        });
 
         $storageClientMock
             ->method('apiPostJson')
@@ -163,9 +189,6 @@ class DataGatewayMigratorTest extends TestCase
                 function (string $url) use ($newWorkspaceData): array {
                     if ($url === 'workspaces') {
                         return $newWorkspaceData;
-                    }
-                    if (str_contains($url, 'public-key')) {
-                        return [];
                     }
                     return [];
                 },
@@ -180,7 +203,12 @@ class DataGatewayMigratorTest extends TestCase
                 return [];
             });
 
-        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator = new DataGatewayMigrator(
+            $storageClientMock,
+            $logger,
+            false,
+            $this->createEncryptionClientMock(),
+        );
         $migrator->migrate();
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
@@ -205,7 +233,8 @@ class DataGatewayMigratorTest extends TestCase
         self::assertSame('snowflake-service-keypair', $db['loginType']);
         self::assertArrayHasKey('#privateKey', $db);
         self::assertIsString($db['#privateKey']);
-        self::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $db['#privateKey']);
+        // The key should be encrypted now
+        self::assertStringStartsWith('KBC::', $db['#privateKey']);
     }
 
     public function testMigrateMultipleConfigurationsWithSharedWorkspace(): void
@@ -249,11 +278,8 @@ class DataGatewayMigratorTest extends TestCase
 
         $workspaceCreateCount = 0;
 
-        /** @var StorageClient&MockObject $storageClientMock */
-        $storageClientMock = $this->createMock(StorageClient::class);
-        $storageClientMock
-            ->method('apiGet')
-            ->willReturnCallback(function (string $url) use ($configData1, $configData2): array {
+        $storageClientMock = $this->createStorageClientMock(
+            function (string $url) use ($configData1, $configData2): array {
                 if (str_contains($url, 'components?')) {
                     return [
                         [
@@ -272,7 +298,8 @@ class DataGatewayMigratorTest extends TestCase
                     return $configData2;
                 }
                 return [];
-            });
+            },
+        );
 
         $storageClientMock
             ->method('apiPostJson')
@@ -286,7 +313,12 @@ class DataGatewayMigratorTest extends TestCase
 
         $storageClientMock->method('apiPutJson')->willReturn([]);
 
-        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator = new DataGatewayMigrator(
+            $storageClientMock,
+            $logger,
+            false,
+            $this->createEncryptionClientMock(),
+        );
         $migrator->migrate();
 
         // Only one workspace should be created (second config reuses the first)
@@ -327,26 +359,22 @@ class DataGatewayMigratorTest extends TestCase
             ],
         ];
 
-        /** @var StorageClient&MockObject $storageClientMock */
-        $storageClientMock = $this->createMock(StorageClient::class);
-        $storageClientMock
-            ->method('apiGet')
-            ->willReturnCallback(function (string $url) use ($configData): array {
-                if (str_contains($url, 'components?')) {
-                    return [
-                        [
-                            'id' => Config::DATA_GATEWAY_COMPONENT,
-                            'configurations' => [
-                                ['id' => 'config-1'],
-                            ],
+        $storageClientMock = $this->createStorageClientMock(function (string $url) use ($configData): array {
+            if (str_contains($url, 'components?')) {
+                return [
+                    [
+                        'id' => Config::DATA_GATEWAY_COMPONENT,
+                        'configurations' => [
+                            ['id' => 'config-1'],
                         ],
-                    ];
-                }
-                if (str_contains($url, 'configs/config-1')) {
-                    return $configData;
-                }
-                return [];
-            });
+                    ],
+                ];
+            }
+            if (str_contains($url, 'configs/config-1')) {
+                return $configData;
+            }
+            return [];
+        });
 
         $storageClientMock
             ->method('apiPostJson')
@@ -359,7 +387,12 @@ class DataGatewayMigratorTest extends TestCase
 
         $storageClientMock->method('apiPutJson')->willReturn([]);
 
-        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator = new DataGatewayMigrator(
+            $storageClientMock,
+            $logger,
+            false,
+            $this->createEncryptionClientMock(),
+        );
         $migrator->migrate();
 
         $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
@@ -394,11 +427,8 @@ class DataGatewayMigratorTest extends TestCase
 
         $workspaceCreateCount = 0;
 
-        /** @var StorageClient&MockObject $storageClientMock */
-        $storageClientMock = $this->createMock(StorageClient::class);
-        $storageClientMock
-            ->method('apiGet')
-            ->willReturnCallback(function (string $url) use ($configData1, $configData2): array {
+        $storageClientMock = $this->createStorageClientMock(
+            function (string $url) use ($configData1, $configData2): array {
                 if (str_contains($url, 'components?')) {
                     return [
                         [
@@ -417,7 +447,8 @@ class DataGatewayMigratorTest extends TestCase
                     return $configData2;
                 }
                 return [];
-            });
+            },
+        );
 
         $storageClientMock
             ->method('apiPostJson')
@@ -441,7 +472,12 @@ class DataGatewayMigratorTest extends TestCase
 
         $storageClientMock->method('apiPutJson')->willReturn([]);
 
-        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator = new DataGatewayMigrator(
+            $storageClientMock,
+            $logger,
+            false,
+            $this->createEncryptionClientMock(),
+        );
         $migrator->migrate();
 
         // Two workspaces should be created (different source workspaceIds)

--- a/tests/phpunit/Migrator/DataGatewayMigratorTest.php
+++ b/tests/phpunit/Migrator/DataGatewayMigratorTest.php
@@ -1,0 +1,454 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AppProjectMigrate\Tests\Migrator;
+
+use Keboola\AppProjectMigrate\Config;
+use Keboola\AppProjectMigrate\Migrator\DataGatewayMigrator;
+use Keboola\StorageApi\Client as StorageClient;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Monolog\LogRecord;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class DataGatewayMigratorTest extends TestCase
+{
+    public function testNoDataGatewayConfigurations(): void
+    {
+        $logsHandler = new TestHandler();
+        $logger = new Logger('tests', [$logsHandler]);
+
+        /** @var StorageClient&MockObject $storageClientMock */
+        $storageClientMock = $this->createMock(StorageClient::class);
+        $storageClientMock
+            ->method('apiGet')
+            ->willReturnCallback(function (string $url): array {
+                if (str_contains($url, 'components?')) {
+                    return []; // No components
+                }
+                return [];
+            });
+
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator->migrate();
+
+        $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
+        self::assertContains('Migrating Data Gateway configurations', $messages);
+        self::assertContains('No Data Gateway configurations found.', $messages);
+    }
+
+    public function testNoDataGatewayConfigurationsWhenComponentExistsButEmpty(): void
+    {
+        $logsHandler = new TestHandler();
+        $logger = new Logger('tests', [$logsHandler]);
+
+        /** @var StorageClient&MockObject $storageClientMock */
+        $storageClientMock = $this->createMock(StorageClient::class);
+        $storageClientMock
+            ->method('apiGet')
+            ->willReturnCallback(function (string $url): array {
+                if (str_contains($url, 'components?')) {
+                    return [
+                        [
+                            'id' => Config::DATA_GATEWAY_COMPONENT,
+                            'configurations' => [], // Empty configurations
+                        ],
+                    ];
+                }
+                return [];
+            });
+
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator->migrate();
+
+        $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
+        self::assertContains('No Data Gateway configurations found.', $messages);
+    }
+
+    public function testDryRunMode(): void
+    {
+        $logsHandler = new TestHandler();
+        $logger = new Logger('tests', [$logsHandler]);
+
+        /** @var StorageClient&MockObject $storageClientMock */
+        $storageClientMock = $this->createMock(StorageClient::class);
+        $storageClientMock
+            ->method('apiGet')
+            ->willReturnCallback(function (string $url): array {
+                if (str_contains($url, 'components?')) {
+                    return [
+                        [
+                            'id' => Config::DATA_GATEWAY_COMPONENT,
+                            'configurations' => [
+                                ['id' => 'config-1'],
+                                ['id' => 'config-2'],
+                            ],
+                        ],
+                    ];
+                }
+                return [];
+            });
+
+        // In dry-run mode, no workspace should be created
+        $storageClientMock->expects(self::never())->method('apiPostJson');
+
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger, dryRun: true);
+        $migrator->migrate();
+
+        $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
+        self::assertContains('[dry-run] Would migrate Data Gateway config "config-1"', $messages);
+        self::assertContains('[dry-run] Would migrate Data Gateway config "config-2"', $messages);
+        self::assertContains('Data Gateway configurations migrated', $messages);
+    }
+
+    public function testMigrateSingleConfiguration(): void
+    {
+        $logsHandler = new TestHandler();
+        $logger = new Logger('tests', [$logsHandler]);
+
+        $configData = [
+            'id' => 'config-1',
+            'name' => 'My Data Gateway',
+            'configuration' => [
+                'parameters' => [
+                    'db' => [
+                        'workspaceId' => 100,
+                        'host' => 'old-host.snowflake.com',
+                        'user' => 'OLD_USER',
+                    ],
+                ],
+            ],
+        ];
+
+        $newWorkspaceData = [
+            'id' => 200,
+            'connection' => [
+                'host' => 'new-host.snowflake.com',
+                'user' => 'NEW_USER',
+                'schema' => 'NEW_SCHEMA',
+                'warehouse' => 'NEW_WAREHOUSE',
+                'database' => 'NEW_DATABASE',
+                'role' => 'NEW_ROLE',
+            ],
+        ];
+
+        $updatedConfiguration = null;
+
+        /** @var StorageClient&MockObject $storageClientMock */
+        $storageClientMock = $this->createMock(StorageClient::class);
+        $storageClientMock
+            ->method('apiGet')
+            ->willReturnCallback(function (string $url) use ($configData): array {
+                if (str_contains($url, 'components?')) {
+                    return [
+                        [
+                            'id' => Config::DATA_GATEWAY_COMPONENT,
+                            'configurations' => [
+                                ['id' => 'config-1'],
+                            ],
+                        ],
+                    ];
+                }
+                if (str_contains($url, 'configs/config-1')) {
+                    return $configData;
+                }
+                return [];
+            });
+
+        $storageClientMock
+            ->method('apiPostJson')
+            ->willReturnCallback(
+                function (string $url) use ($newWorkspaceData): array {
+                    if ($url === 'workspaces') {
+                        return $newWorkspaceData;
+                    }
+                    if (str_contains($url, 'public-key')) {
+                        return [];
+                    }
+                    return [];
+                },
+            );
+
+        $storageClientMock
+            ->method('apiPutJson')
+            ->willReturnCallback(function (string $url, array $data) use (&$updatedConfiguration): array {
+                if (str_contains($url, 'configs/config-1')) {
+                    $updatedConfiguration = $data;
+                }
+                return [];
+            });
+
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator->migrate();
+
+        $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
+        self::assertContains('Migrating Data Gateway config "config-1"', $messages);
+        self::assertContains('Data Gateway config "config-1" migrated to workspace 200', $messages);
+        self::assertContains(
+            'Data Gateway workspace data NOT migrated for config "config-1". User must load data manually.',
+            $messages,
+        );
+
+        // Verify configuration was updated with new workspace credentials
+        self::assertNotNull($updatedConfiguration);
+        self::assertArrayHasKey('configuration', $updatedConfiguration);
+        /** @var array{configuration: array{parameters: array{db: array<string, mixed>}}} $updatedConfiguration */
+        $db = $updatedConfiguration['configuration']['parameters']['db'];
+        self::assertSame('new-host.snowflake.com', $db['host']);
+        self::assertSame('NEW_USER', $db['user']);
+        self::assertSame('NEW_SCHEMA', $db['schema']);
+        self::assertSame('NEW_WAREHOUSE', $db['warehouse']);
+        self::assertSame('NEW_DATABASE', $db['database']);
+        self::assertSame(200, $db['workspaceId']);
+        self::assertSame('snowflake-service-keypair', $db['loginType']);
+        self::assertArrayHasKey('#privateKey', $db);
+        self::assertIsString($db['#privateKey']);
+        self::assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $db['#privateKey']);
+    }
+
+    public function testMigrateMultipleConfigurationsWithSharedWorkspace(): void
+    {
+        $logsHandler = new TestHandler();
+        $logger = new Logger('tests', [$logsHandler]);
+
+        $sharedWorkspaceId = 100;
+
+        $configData1 = [
+            'id' => 'config-1',
+            'name' => 'Data Gateway 1',
+            'configuration' => [
+                'parameters' => [
+                    'db' => ['workspaceId' => $sharedWorkspaceId],
+                ],
+            ],
+        ];
+
+        $configData2 = [
+            'id' => 'config-2',
+            'name' => 'Data Gateway 2',
+            'configuration' => [
+                'parameters' => [
+                    'db' => ['workspaceId' => $sharedWorkspaceId], // Same workspace
+                ],
+            ],
+        ];
+
+        $newWorkspaceData = [
+            'id' => 200,
+            'connection' => [
+                'host' => 'new-host.snowflake.com',
+                'user' => 'NEW_USER',
+                'schema' => 'NEW_SCHEMA',
+                'warehouse' => 'NEW_WAREHOUSE',
+                'database' => 'NEW_DATABASE',
+                'role' => null,
+            ],
+        ];
+
+        $workspaceCreateCount = 0;
+
+        /** @var StorageClient&MockObject $storageClientMock */
+        $storageClientMock = $this->createMock(StorageClient::class);
+        $storageClientMock
+            ->method('apiGet')
+            ->willReturnCallback(function (string $url) use ($configData1, $configData2): array {
+                if (str_contains($url, 'components?')) {
+                    return [
+                        [
+                            'id' => Config::DATA_GATEWAY_COMPONENT,
+                            'configurations' => [
+                                ['id' => 'config-1'],
+                                ['id' => 'config-2'],
+                            ],
+                        ],
+                    ];
+                }
+                if (str_contains($url, 'configs/config-1')) {
+                    return $configData1;
+                }
+                if (str_contains($url, 'configs/config-2')) {
+                    return $configData2;
+                }
+                return [];
+            });
+
+        $storageClientMock
+            ->method('apiPostJson')
+            ->willReturnCallback(function (string $url) use ($newWorkspaceData, &$workspaceCreateCount): array {
+                if ($url === 'workspaces') {
+                    $workspaceCreateCount++;
+                    return $newWorkspaceData;
+                }
+                return [];
+            });
+
+        $storageClientMock->method('apiPutJson')->willReturn([]);
+
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator->migrate();
+
+        // Only one workspace should be created (second config reuses the first)
+        self::assertSame(1, $workspaceCreateCount);
+
+        $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
+        self::assertContains('Migrating Data Gateway config "config-1"', $messages);
+        self::assertContains('Reusing already migrated workspace 200 for config "config-2"', $messages);
+    }
+
+    public function testMigrateConfigurationWithoutWorkspaceId(): void
+    {
+        $logsHandler = new TestHandler();
+        $logger = new Logger('tests', [$logsHandler]);
+
+        $configData = [
+            'id' => 'config-1',
+            'name' => 'Data Gateway without workspace',
+            'configuration' => [
+                'parameters' => [
+                    'db' => [
+                        'host' => 'some-host.snowflake.com',
+                        // No workspaceId
+                    ],
+                ],
+            ],
+        ];
+
+        $newWorkspaceData = [
+            'id' => 200,
+            'connection' => [
+                'host' => 'new-host.snowflake.com',
+                'user' => 'NEW_USER',
+                'schema' => 'NEW_SCHEMA',
+                'warehouse' => 'NEW_WAREHOUSE',
+                'database' => 'NEW_DATABASE',
+                'role' => null,
+            ],
+        ];
+
+        /** @var StorageClient&MockObject $storageClientMock */
+        $storageClientMock = $this->createMock(StorageClient::class);
+        $storageClientMock
+            ->method('apiGet')
+            ->willReturnCallback(function (string $url) use ($configData): array {
+                if (str_contains($url, 'components?')) {
+                    return [
+                        [
+                            'id' => Config::DATA_GATEWAY_COMPONENT,
+                            'configurations' => [
+                                ['id' => 'config-1'],
+                            ],
+                        ],
+                    ];
+                }
+                if (str_contains($url, 'configs/config-1')) {
+                    return $configData;
+                }
+                return [];
+            });
+
+        $storageClientMock
+            ->method('apiPostJson')
+            ->willReturnCallback(function (string $url) use ($newWorkspaceData): array {
+                if ($url === 'workspaces') {
+                    return $newWorkspaceData;
+                }
+                return [];
+            });
+
+        $storageClientMock->method('apiPutJson')->willReturn([]);
+
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator->migrate();
+
+        $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
+        self::assertContains('Migrating Data Gateway config "config-1"', $messages);
+        self::assertContains('Data Gateway config "config-1" migrated to workspace 200', $messages);
+    }
+
+    public function testMigrateMultipleConfigurationsWithDifferentWorkspaces(): void
+    {
+        $logsHandler = new TestHandler();
+        $logger = new Logger('tests', [$logsHandler]);
+
+        $configData1 = [
+            'id' => 'config-1',
+            'name' => 'Data Gateway 1',
+            'configuration' => [
+                'parameters' => [
+                    'db' => ['workspaceId' => 100],
+                ],
+            ],
+        ];
+
+        $configData2 = [
+            'id' => 'config-2',
+            'name' => 'Data Gateway 2',
+            'configuration' => [
+                'parameters' => [
+                    'db' => ['workspaceId' => 101], // Different workspace
+                ],
+            ],
+        ];
+
+        $workspaceCreateCount = 0;
+
+        /** @var StorageClient&MockObject $storageClientMock */
+        $storageClientMock = $this->createMock(StorageClient::class);
+        $storageClientMock
+            ->method('apiGet')
+            ->willReturnCallback(function (string $url) use ($configData1, $configData2): array {
+                if (str_contains($url, 'components?')) {
+                    return [
+                        [
+                            'id' => Config::DATA_GATEWAY_COMPONENT,
+                            'configurations' => [
+                                ['id' => 'config-1'],
+                                ['id' => 'config-2'],
+                            ],
+                        ],
+                    ];
+                }
+                if (str_contains($url, 'configs/config-1')) {
+                    return $configData1;
+                }
+                if (str_contains($url, 'configs/config-2')) {
+                    return $configData2;
+                }
+                return [];
+            });
+
+        $storageClientMock
+            ->method('apiPostJson')
+            ->willReturnCallback(function (string $url) use (&$workspaceCreateCount): array {
+                if ($url === 'workspaces') {
+                    $workspaceCreateCount++;
+                    return [
+                        'id' => 200 + $workspaceCreateCount,
+                        'connection' => [
+                            'host' => 'host.snowflake.com',
+                            'user' => 'USER',
+                            'schema' => 'SCHEMA',
+                            'warehouse' => 'WAREHOUSE',
+                            'database' => 'DATABASE',
+                            'role' => null,
+                        ],
+                    ];
+                }
+                return [];
+            });
+
+        $storageClientMock->method('apiPutJson')->willReturn([]);
+
+        $migrator = new DataGatewayMigrator($storageClientMock, $logger);
+        $migrator->migrate();
+
+        // Two workspaces should be created (different source workspaceIds)
+        self::assertSame(2, $workspaceCreateCount);
+
+        $messages = array_map(fn(LogRecord $r) => $r->message, $logsHandler->getRecords());
+        self::assertContains('Data Gateway config "config-1" migrated to workspace 201', $messages);
+        self::assertContains('Data Gateway config "config-2" migrated to workspace 202', $messages);
+    }
+}


### PR DESCRIPTION
## Summary

- Add migration support for `keboola.app-data-gateway` component
- Create new READER workspaces with keypair authentication in destination project
- Encrypt private keys via Encryption API (componentId + configId scoped)
- Support workspace sharing between multiple configurations using the same source workspace
- Add `migrateDataGateway` config parameter (default: `true`)

**Note:** Workspace data is NOT migrated - users must load data manually after migration.

## Changes

- New `DataGatewayMigrator` class with full test coverage
- Updated Config, ConfigDefinition for new parameter
- Updated Migrate.php to call DataGatewayMigrator
- Documentation in README.md

## Test plan

- [x] Unit tests for DataGatewayMigrator (7 test cases)
- [x] Integration test with real migration
- [x] Verified Data Gateway job runs successfully after migration
- [x] phpcs + phpstan pass
