### PR TITLE
feat: add migrateComponents and migrateConfigurations filter parameters

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -133,6 +133,16 @@ class Config extends BaseConfig
         return $this->getBoolValue(['parameters', 'preserveTimestamp']);
     }
 
+    /**
+     * @return array<int, string>
+     */
+    public function getMigrateComponents(): array
+    {
+        /** @var array<int, string> $value */
+        $value = $this->getArrayValue(['parameters', 'migrateComponents'], []);
+        return $value;
+    }
+
     public function checkEmptyProject(): bool
     {
         return $this->getBoolValue(['parameters', 'checkEmptyProject']);

--- a/src/Config.php
+++ b/src/Config.php
@@ -143,6 +143,16 @@ class Config extends BaseConfig
         return $value;
     }
 
+    /**
+     * @return array<int, string>
+     */
+    public function getMigrateConfigurations(): array
+    {
+        /** @var array<int, string> $value */
+        $value = $this->getArrayValue(['parameters', 'migrateConfigurations'], []);
+        return $value;
+    }
+
     public function checkEmptyProject(): bool
     {
         return $this->getBoolValue(['parameters', 'checkEmptyProject']);

--- a/src/ConfigDefinition.php
+++ b/src/ConfigDefinition.php
@@ -31,6 +31,7 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->booleanNode('migrateNotifications')->defaultTrue()->end()
                 ->booleanNode('migrateStructureOnly')->defaultFalse()->end()
                 ->booleanNode('migrateSecrets')->defaultFalse()->end()
+                ->arrayNode('migrateComponents')->prototype('scalar')->end()->end()
                 ->booleanNode('migrateBuckets')->defaultTrue()->end()
                 ->booleanNode('migrateTables')->defaultTrue()->end()
                 ->booleanNode('migrateProjectMetadata')->defaultTrue()->end()

--- a/src/ConfigDefinition.php
+++ b/src/ConfigDefinition.php
@@ -32,6 +32,7 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->booleanNode('migrateStructureOnly')->defaultFalse()->end()
                 ->booleanNode('migrateSecrets')->defaultFalse()->end()
                 ->arrayNode('migrateComponents')->prototype('scalar')->end()->end()
+                ->arrayNode('migrateConfigurations')->prototype('scalar')->end()->end()
                 ->booleanNode('migrateBuckets')->defaultTrue()->end()
                 ->booleanNode('migrateTables')->defaultTrue()->end()
                 ->booleanNode('migrateProjectMetadata')->defaultTrue()->end()

--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -164,11 +164,20 @@ class Migrate
             return;
         }
 
+        $migrateComponents = $this->config->getMigrateComponents();
+
         foreach ($components as $component) {
             /** @var array{id: string, configurations: array} $component */
             if (in_array($component['id'], self::OBSOLETE_COMPONENTS, true)) {
                 $this->logger->info(
                     sprintf('Components "%s" is obsolete, skipping migration...', $component['id']),
+                    ['secrets'],
+                );
+                continue;
+            }
+            if ($migrateComponents && !in_array($component['id'], $migrateComponents, true)) {
+                $this->logger->info(
+                    sprintf('Component "%s" is not in the migrateComponents list, skipping...', $component['id']),
                     ['secrets'],
                 );
                 continue;

--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -165,6 +165,7 @@ class Migrate
         }
 
         $migrateComponents = $this->config->getMigrateComponents();
+        $migrateConfigurations = $this->config->getMigrateConfigurations();
 
         foreach ($components as $component) {
             /** @var array{id: string, configurations: array} $component */
@@ -185,6 +186,17 @@ class Migrate
 
             foreach ($component['configurations'] as $config) {
                 /** @var array{id: string} $config */
+                if ($migrateConfigurations && !in_array($config['id'], $migrateConfigurations, true)) {
+                    $this->logger->info(
+                        sprintf(
+                            'Configuration "%s" of component "%s" not in migrateConfigurations, skipping...',
+                            $config['id'],
+                            $component['id'],
+                        ),
+                        ['secrets'],
+                    );
+                    continue;
+                }
                 $this->logger->info(
                     sprintf(
                         '%sMigrating configuration "%s" of component "%s"',


### PR DESCRIPTION
# feat: add migrateComponents and migrateConfigurations filter parameters

## Summary

Adds two new configuration parameters to filter which component configurations are migrated via the encryption API during secret migration:

- **`migrateComponents`** (array of component IDs): Only listed components are processed; others are skipped with a log message. Empty (default) = migrate all.
- **`migrateConfigurations`** (array of configuration IDs): Only listed configuration IDs are processed; others are skipped. Empty (default) = migrate all.

Both filters can be combined: `migrateComponents` filters at the component level first, then `migrateConfigurations` filters individual configs within the remaining components.

**Changes:**
- `ConfigDefinition.php`: new `migrateComponents` and `migrateConfigurations` array parameters
- `Config.php`: new `getMigrateComponents()` and `getMigrateConfigurations()` accessors
- `Migrate.php`: filter loop in `migrateSecrets()` to skip components/configs not in the respective lists

**Example usage:**
```json
{
  "parameters": {
    "migrateSecrets": true,
    "#sourceManageToken": "...",
    "migrateComponents": ["keboola.ex-db-snowflake", "keboola.wr-db-snowflake"],
    "migrateConfigurations": ["12345", "67890"]
  }
}
```

## Review & Testing Checklist for Human

- [ ] **Configuration ID uniqueness**: `migrateConfigurations` filters by config ID globally across all (non-filtered) components. If the same config ID exists under different components, both will be included. Verify this is acceptable, or whether the filter should be scoped per-component (e.g. `{"componentId": "...", "configId": "..."}`).
- [ ] **Interaction with `restoreConfigs`**: When `migrateSecrets` is `true`, the restore step sets `restoreConfigs: false`. This means components/configs NOT in the filter lists will have **no configs restored at all** (neither via backup/restore nor encryption API). Verify this is the intended behavior.
- [ ] **No validation on parameter combination**: Both `migrateComponents` and `migrateConfigurations` are silently ignored if `migrateSecrets` is `false`. Consider whether a validation rule should enforce that these require `migrateSecrets: true`.
- [ ] **No unit tests added**: The filtering logic and new config accessors have no test coverage. Recommend manual testing with `migrateSecrets: true` and various filter combinations, verifying only matched components/configs are migrated and others are logged as skipped.

### Notes
- Tag `163-component-list` on first commit (component filter only)
- Tag `163-component-list-filter` on second commit (adds configuration filter)
- Link to Devin run: https://app.devin.ai/sessions/3b0c11b1f42f4c7abbd6c0ae4e7db4ad
- Requested by: @yustme

## Release Notes
**Justification, description**

Adds optional `migrateComponents` and `migrateConfigurations` parameters to allow selective migration of component configurations with secrets, instead of all-or-nothing.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Backward-compatible — both parameters default to empty arrays, preserving existing migrate-all behavior.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/app-project-migrate/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
