### PR TITLE
fix: cast branchId to string in migrateSecrets() call

### DIFF
--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -204,7 +204,7 @@ class Migrate
                             $this->destinationProjectToken,
                             $component['id'],
                             $config['id'],
-                            $defaultSourceBranch['id'],
+                            (string) $defaultSourceBranch['id'],
                             $this->config->isDryRun(),
                         );
                 } catch (EncryptionClientException $e) {


### PR DESCRIPTION
## Summary

Fixes a `TypeError` crash when running migration with `migrateSecrets: true`. The `DevBranches::listBranches()` Storage API returns branch `id` as `int`, but `Migrations::migrateConfiguration()` in `encryption-api-php-client` declares `string $branchId`. The missing `(string)` cast causes an immediate fatal error on the first configuration.

This is a regression introduced in 3.0.0 during the refactor in commit `8a0e992` — the cast previously existed (added in commit `3d133ee` by @romanpistek) but was lost when the method was rewritten.

**Error:** `TypeError: Keboola\EncryptionApiClient\Migrations::migrateConfiguration(): Argument #6 ($branchId) must be of type string, int given`

## Review & Testing Checklist for Human

- [ ] Verify no other usages of `$defaultSourceBranch['id']` have the same int-vs-string issue (the `@var` annotation on line 160 incorrectly claims `id` is `string` — pre-existing, not introduced here)
- [ ] Test a migration run with `migrateSecrets: true` to confirm the TypeError is resolved and secrets migrate successfully

### Notes
- Link to Devin session: https://app.devin.ai/sessions/dea7623bc6bc4131b95c35616054a0b8
- Requested by: @yustme
- Confirmed via Datadog logs on jobs `63273531` and `63277380` (project 2730, `europe-west3.gcp` stack) that this is the root cause

## Release Notes
**Justification, description**

Fix TypeError crash when migrating secrets — branch ID from Storage API is int but encryption-api-php-client expects string.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Without this fix, any migration with `migrateSecrets: true` crashes immediately on the first configuration. The fix is a single-character type cast with no behavioral change for any other code path.

**Deployment Plan**

Merge and tag a new release.

**Rollback Plan**

Revert the commit.

**Post-Release Support Plan**

N/A