### PR TITLE
[AJDA-2427] Propagate new settings to child migration jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The request contains the following parameters:
 - `includeWorkspaceSchemas`: Array of workspace schema names to include in migration (default: [])
 - `preserveTimestamp`: Preserve original table timestamps during data migration (default: false)
 - `forcePrimaryKeyNotNull`: When true, forces primary key columns to be NOT NULL during migration (default: false). Propagated to both `app-project-restore` and `app-project-migrate-large-tables`.
-- `tableParallelism`: Number of tables to migrate in parallel during restore (optional, no default). Propagated to `app-project-restore` only when set.
+- `tableParallelism`: Number of tables to migrate in parallel during restore (default: `5`). Propagated to `app-project-restore`.
 - `gcsLargeTable`: Configuration for GCS large table migration (propagated to `app-project-migrate-large-tables`):
   - `parallelChunks`: Number of parallel chunks to use during GCS table migration (default: `3`, max: `20`)
   - `chunkSize`: Size of each chunk in MB during GCS table migration (default: `150`)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ The request contains the following parameters:
 - `sourceByodb`: Source BYODB identifier (required when `isSourceByodb` is true)
 - `includeWorkspaceSchemas`: Array of workspace schema names to include in migration (default: [])
 - `preserveTimestamp`: Preserve original table timestamps during data migration (default: false)
+- `forcePrimaryKeyNotNull`: When true, forces primary key columns to be NOT NULL during migration (default: false). Propagated to both `app-project-restore` and `app-project-migrate-large-tables`.
+- `tableParallelism`: Number of tables to migrate in parallel during restore (optional, no default). Propagated to `app-project-restore` only when set.
+- `gcsLargeTable`: Configuration for GCS large table migration (propagated to `app-project-migrate-large-tables`):
+  - `parallelChunks`: Number of parallel chunks to use during GCS table migration (default: `3`, max: `20`)
+  - `chunkSize`: Size of each chunk in MB during GCS table migration (default: `150`)
 - `componentsDevTag`: Object with dev branch tags for migration components:
   - `backup`: Dev tag for the backup component
   - `restore`: Dev tag for the restore component

--- a/src/Config.php
+++ b/src/Config.php
@@ -137,6 +137,29 @@ class Config extends BaseConfig
         return $this->getBoolValue(['parameters', 'preserveTimestamp']);
     }
 
+    public function isForcePrimaryKeyNotNull(): bool
+    {
+        return $this->getBoolValue(['parameters', 'forcePrimaryKeyNotNull']);
+    }
+
+    public function getTableParallelism(): ?int
+    {
+        $value = $this->getValue(['parameters', 'tableParallelism']);
+        return is_int($value) ? $value : null;
+    }
+
+    public function getGcsLargeTableParallelChunks(): int
+    {
+        $value = $this->getValue(['parameters', 'gcsLargeTable', 'parallelChunks'], 3);
+        return is_int($value) ? $value : 3;
+    }
+
+    public function getGcsLargeTableChunkSize(): int
+    {
+        $value = $this->getValue(['parameters', 'gcsLargeTable', 'chunkSize'], 150);
+        return is_int($value) ? $value : 150;
+    }
+
     public function checkEmptyProject(): bool
     {
         return $this->getBoolValue(['parameters', 'checkEmptyProject']);

--- a/src/Config.php
+++ b/src/Config.php
@@ -142,10 +142,10 @@ class Config extends BaseConfig
         return $this->getBoolValue(['parameters', 'forcePrimaryKeyNotNull']);
     }
 
-    public function getTableParallelism(): ?int
+    public function getTableParallelism(): int
     {
-        $value = $this->getValue(['parameters', 'tableParallelism']);
-        return is_int($value) ? $value : null;
+        $value = $this->getValue(['parameters', 'tableParallelism'], 5);
+        return is_int($value) ? $value : 5;
     }
 
     public function getGcsLargeTableParallelChunks(): int

--- a/src/Config.php
+++ b/src/Config.php
@@ -144,20 +144,17 @@ class Config extends BaseConfig
 
     public function getTableParallelism(): int
     {
-        $value = $this->getValue(['parameters', 'tableParallelism'], 5);
-        return is_int($value) ? $value : 5;
+        return $this->getIntValue(['parameters', 'tableParallelism'], 5);
     }
 
     public function getGcsLargeTableParallelChunks(): int
     {
-        $value = $this->getValue(['parameters', 'gcsLargeTable', 'parallelChunks'], 3);
-        return is_int($value) ? $value : 3;
+        return $this->getIntValue(['parameters', 'gcsLargeTable', 'parallelChunks'], 3);
     }
 
     public function getGcsLargeTableChunkSize(): int
     {
-        $value = $this->getValue(['parameters', 'gcsLargeTable', 'chunkSize'], 150);
-        return is_int($value) ? $value : 150;
+        return $this->getIntValue(['parameters', 'gcsLargeTable', 'chunkSize'], 150);
     }
 
     public function checkEmptyProject(): bool

--- a/src/ConfigDefinition.php
+++ b/src/ConfigDefinition.php
@@ -43,7 +43,7 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->arrayNode('includeWorkspaceSchemas')->prototype('scalar')->end()->end()
                 ->booleanNode('preserveTimestamp')->defaultFalse()->end()
                 ->booleanNode('forcePrimaryKeyNotNull')->defaultFalse()->end()
-                ->integerNode('tableParallelism')->defaultNull()->end()
+                ->integerNode('tableParallelism')->defaultValue(5)->end()
                 ->arrayNode('gcsLargeTable')
                     ->children()
                         ->integerNode('parallelChunks')->defaultValue(3)

--- a/src/ConfigDefinition.php
+++ b/src/ConfigDefinition.php
@@ -42,6 +42,23 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->scalarNode('sourceByodb')->end()
                 ->arrayNode('includeWorkspaceSchemas')->prototype('scalar')->end()->end()
                 ->booleanNode('preserveTimestamp')->defaultFalse()->end()
+                ->booleanNode('forcePrimaryKeyNotNull')->defaultFalse()->end()
+                ->integerNode('tableParallelism')->defaultNull()->end()
+                ->arrayNode('gcsLargeTable')
+                    ->children()
+                        ->integerNode('parallelChunks')->defaultValue(3)
+                            ->validate()->always(function ($v) {
+                                if ($v > 20) {
+                                    throw new InvalidConfigurationException(
+                                        'gcsLargeTable.parallelChunks max is 20.',
+                                    );
+                                }
+                                return $v;
+                            })->end()
+                        ->end()
+                        ->integerNode('chunkSize')->defaultValue(150)->end()
+                    ->end()
+                ->end()
                 ->arrayNode('componentsDevTag')
                     ->children()
                         ->scalarNode('backup')->end()

--- a/src/ConfigDefinition.php
+++ b/src/ConfigDefinition.php
@@ -43,11 +43,25 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->arrayNode('includeWorkspaceSchemas')->prototype('scalar')->end()->end()
                 ->booleanNode('preserveTimestamp')->defaultFalse()->end()
                 ->booleanNode('forcePrimaryKeyNotNull')->defaultFalse()->end()
-                ->integerNode('tableParallelism')->defaultValue(5)->end()
+                ->integerNode('tableParallelism')->defaultValue(5)
+                    ->validate()->always(function ($v) {
+                        if ($v < 1) {
+                            throw new InvalidConfigurationException(
+                                'tableParallelism must be at least 1.',
+                            );
+                        }
+                        return $v;
+                    })->end()
+                ->end()
                 ->arrayNode('gcsLargeTable')
                     ->children()
                         ->integerNode('parallelChunks')->defaultValue(3)
                             ->validate()->always(function ($v) {
+                                if ($v < 1) {
+                                    throw new InvalidConfigurationException(
+                                        'gcsLargeTable.parallelChunks must be at least 1.',
+                                    );
+                                }
                                 if ($v > 20) {
                                     throw new InvalidConfigurationException(
                                         'gcsLargeTable.parallelChunks max is 20.',
@@ -56,7 +70,16 @@ class ConfigDefinition extends BaseConfigDefinition
                                 return $v;
                             })->end()
                         ->end()
-                        ->integerNode('chunkSize')->defaultValue(150)->end()
+                        ->integerNode('chunkSize')->defaultValue(150)
+                            ->validate()->always(function ($v) {
+                                if ($v < 1) {
+                                    throw new InvalidConfigurationException(
+                                        'gcsLargeTable.chunkSize must be at least 1.',
+                                    );
+                                }
+                                return $v;
+                            })->end()
+                        ->end()
                     ->end()
                 ->end()
                 ->arrayNode('componentsDevTag')

--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -478,12 +478,12 @@ class Migrate
      *     restoreProjectMetadata: bool,
      *     checkEmptyProject: bool,
      *     forcePrimaryKeyNotNull: bool,
-     *     tableParallelism?: int
+     *     tableParallelism: int
      * }
      */
     private function getCommonRestoreParameters(): array
     {
-        $params = [
+        return [
             'dryRun' => $this->config->isDryRun(),
             'useDefaultBackend' => true,
             'restoreConfigs' => $this->config->shouldMigrateSecrets() === false,
@@ -495,14 +495,8 @@ class Migrate
             'restoreProjectMetadata' => $this->config->shouldMigrateProjectMetadata(),
             'checkEmptyProject' => $this->config->checkEmptyProject(),
             'forcePrimaryKeyNotNull' => $this->config->isForcePrimaryKeyNotNull(),
+            'tableParallelism' => $this->config->getTableParallelism(),
         ];
-
-        $tableParallelism = $this->config->getTableParallelism();
-        if ($tableParallelism !== null) {
-            $params['tableParallelism'] = $tableParallelism;
-        }
-
-        return $params;
     }
 
     private function preserveProperSnowflakeWorkspace(

--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -260,6 +260,11 @@ class Migrate
             'sourceByodb' => $this->config->getSourceByodb(),
             'includeWorkspaceSchemas' => $this->config->getIncludeWorkspaceSchemas(),
             'preserveTimestamp' => $this->config->preserveTimestamp(),
+            'forcePrimaryKeyNotNull' => $this->config->isForcePrimaryKeyNotNull(),
+            'gcsLargeTable' => [
+                'parallelChunks' => $this->config->getGcsLargeTableParallelChunks(),
+                'chunkSize' => $this->config->getGcsLargeTableChunkSize(),
+            ],
         ];
 
         if ($this->config->getMigrateDataMode() === 'database') {
@@ -471,12 +476,14 @@ class Migrate
      *     restoreBuckets: bool,
      *     restoreTables: bool,
      *     restoreProjectMetadata: bool,
-     *     checkEmptyProject: bool
+     *     checkEmptyProject: bool,
+     *     forcePrimaryKeyNotNull: bool,
+     *     tableParallelism?: int
      * }
      */
     private function getCommonRestoreParameters(): array
     {
-        return [
+        $params = [
             'dryRun' => $this->config->isDryRun(),
             'useDefaultBackend' => true,
             'restoreConfigs' => $this->config->shouldMigrateSecrets() === false,
@@ -487,7 +494,15 @@ class Migrate
             'restoreTables' => $this->config->shouldMigrateTables(),
             'restoreProjectMetadata' => $this->config->shouldMigrateProjectMetadata(),
             'checkEmptyProject' => $this->config->checkEmptyProject(),
+            'forcePrimaryKeyNotNull' => $this->config->isForcePrimaryKeyNotNull(),
         ];
+
+        $tableParallelism = $this->config->getTableParallelism();
+        if ($tableParallelism !== null) {
+            $params['tableParallelism'] = $tableParallelism;
+        }
+
+        return $params;
     }
 
     private function preserveProperSnowflakeWorkspace(

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -515,7 +515,7 @@ class ConfigTest extends TestCase
         );
 
         self::assertFalse($config->isForcePrimaryKeyNotNull());
-        self::assertSame(5, $config->getTableParallelism());
+        self::assertSame(5, $config->getTableParallelism()); // default value
         self::assertSame(3, $config->getGcsLargeTableParallelChunks());
         self::assertSame(150, $config->getGcsLargeTableChunkSize());
     }
@@ -528,7 +528,7 @@ class ConfigTest extends TestCase
                     'sourceKbcUrl' => 'https://connection.keboola.com',
                     '#sourceKbcToken' => 'token',
                     'forcePrimaryKeyNotNull' => true,
-                    'tableParallelism' => 5,
+                    'tableParallelism' => 10,
                     'gcsLargeTable' => [
                         'parallelChunks' => 10,
                         'chunkSize' => 200,
@@ -539,7 +539,7 @@ class ConfigTest extends TestCase
         );
 
         self::assertTrue($config->isForcePrimaryKeyNotNull());
-        self::assertSame(5, $config->getTableParallelism());
+        self::assertSame(10, $config->getTableParallelism());
         self::assertSame(10, $config->getGcsLargeTableParallelChunks());
         self::assertSame(200, $config->getGcsLargeTableChunkSize());
     }

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -515,7 +515,7 @@ class ConfigTest extends TestCase
         );
 
         self::assertFalse($config->isForcePrimaryKeyNotNull());
-        self::assertNull($config->getTableParallelism());
+        self::assertSame(5, $config->getTableParallelism());
         self::assertSame(3, $config->getGcsLargeTableParallelChunks());
         self::assertSame(150, $config->getGcsLargeTableChunkSize());
     }

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -60,6 +60,36 @@ class ConfigTest extends TestCase
             ],
             'Parameter "db" is allowed only when "dataMode" is set to "database".',
         ];
+
+        yield 'tableParallelism zero' => [
+            ['tableParallelism' => 0],
+            'tableParallelism must be at least 1.',
+        ];
+
+        yield 'tableParallelism negative' => [
+            ['tableParallelism' => -1],
+            'tableParallelism must be at least 1.',
+        ];
+
+        yield 'gcsLargeTable.parallelChunks zero' => [
+            ['gcsLargeTable' => ['parallelChunks' => 0]],
+            'gcsLargeTable.parallelChunks must be at least 1.',
+        ];
+
+        yield 'gcsLargeTable.parallelChunks above max' => [
+            ['gcsLargeTable' => ['parallelChunks' => 21]],
+            'gcsLargeTable.parallelChunks max is 20.',
+        ];
+
+        yield 'gcsLargeTable.chunkSize zero' => [
+            ['gcsLargeTable' => ['chunkSize' => 0]],
+            'gcsLargeTable.chunkSize must be at least 1.',
+        ];
+
+        yield 'gcsLargeTable.chunkSize negative' => [
+            ['gcsLargeTable' => ['chunkSize' => -1]],
+            'gcsLargeTable.chunkSize must be at least 1.',
+        ];
     }
 
     public function testMigrateSecretsConfigValid(): void
@@ -542,25 +572,6 @@ class ConfigTest extends TestCase
         self::assertSame(10, $config->getTableParallelism());
         self::assertSame(10, $config->getGcsLargeTableParallelChunks());
         self::assertSame(200, $config->getGcsLargeTableChunkSize());
-    }
-
-    public function testGcsLargeTableParallelChunksMaxValidation(): void
-    {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('gcsLargeTable.parallelChunks max is 20.');
-
-        new Config(
-            [
-                'parameters' => [
-                    'sourceKbcUrl' => 'https://connection.keboola.com',
-                    '#sourceKbcToken' => 'token',
-                    'gcsLargeTable' => [
-                        'parallelChunks' => 21,
-                    ],
-                ],
-            ],
-            new ConfigDefinition(),
-        );
     }
 
     public function testGetSourceManageTokenDefaultValue(): void

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -502,6 +502,67 @@ class ConfigTest extends TestCase
         self::assertEquals('', $config->getSourceByodb());
     }
 
+    public function testNewParametersDefaultValues(): void
+    {
+        $config = new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => 'https://connection.keboola.com',
+                    '#sourceKbcToken' => 'token',
+                ],
+            ],
+            new ConfigDefinition(),
+        );
+
+        self::assertFalse($config->isForcePrimaryKeyNotNull());
+        self::assertNull($config->getTableParallelism());
+        self::assertSame(3, $config->getGcsLargeTableParallelChunks());
+        self::assertSame(150, $config->getGcsLargeTableChunkSize());
+    }
+
+    public function testNewParametersCustomValues(): void
+    {
+        $config = new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => 'https://connection.keboola.com',
+                    '#sourceKbcToken' => 'token',
+                    'forcePrimaryKeyNotNull' => true,
+                    'tableParallelism' => 5,
+                    'gcsLargeTable' => [
+                        'parallelChunks' => 10,
+                        'chunkSize' => 200,
+                    ],
+                ],
+            ],
+            new ConfigDefinition(),
+        );
+
+        self::assertTrue($config->isForcePrimaryKeyNotNull());
+        self::assertSame(5, $config->getTableParallelism());
+        self::assertSame(10, $config->getGcsLargeTableParallelChunks());
+        self::assertSame(200, $config->getGcsLargeTableChunkSize());
+    }
+
+    public function testGcsLargeTableParallelChunksMaxValidation(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('gcsLargeTable.parallelChunks max is 20.');
+
+        new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => 'https://connection.keboola.com',
+                    '#sourceKbcToken' => 'token',
+                    'gcsLargeTable' => [
+                        'parallelChunks' => 21,
+                    ],
+                ],
+            ],
+            new ConfigDefinition(),
+        );
+    }
+
     public function testGetSourceManageTokenDefaultValue(): void
     {
         $config = new Config(

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -106,6 +106,7 @@ class MigrateTest extends TestCase
                             'restoreTables' => $restoreTables,
                             'restoreProjectMetadata' => $restoreProjectMetadata,
                             'checkEmptyProject' => true,
+                            'forcePrimaryKeyNotNull' => false,
                         ],
                     ),
                 ],
@@ -126,6 +127,11 @@ class MigrateTest extends TestCase
                         'sourceByodb' => '',
                         'includeWorkspaceSchemas' => [],
                         'preserveTimestamp' => false,
+                        'forcePrimaryKeyNotNull' => false,
+                        'gcsLargeTable' => [
+                            'parallelChunks' => 3,
+                            'chunkSize' => 150,
+                        ],
                     ],
                 ],
             ];

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -107,6 +107,7 @@ class MigrateTest extends TestCase
                             'restoreProjectMetadata' => $restoreProjectMetadata,
                             'checkEmptyProject' => true,
                             'forcePrimaryKeyNotNull' => false,
+                            'tableParallelism' => 5,
                         ],
                     ),
                 ],

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -291,6 +291,175 @@ class MigrateTest extends TestCase
         $migrate->run();
     }
 
+    public function testMigrateCustomNewParametersPropagated(): void
+    {
+        /** @var JobRunner&MockObject $sourceJobRunnerMock */
+        $sourceJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
+        /** @var JobRunner&MockObject $destJobRunnerMock */
+        $destJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
+
+        $this->mockAddMethodGenerateAbsReadCredentials($sourceJobRunnerMock);
+        $this->mockAddMethodBackupProject(
+            $sourceJobRunnerMock,
+            ['id' => '222', 'status' => 'success'],
+            true,
+        );
+
+        $sourceProjectUrl = 'https://connection.keboola.com';
+        $sourceProjectToken = 'xyz';
+
+        $absCredentials = [
+            'abs' => [
+                'container' => 'abcdefgh',
+                '#connectionString' => 'https://testConnectionString',
+            ],
+        ];
+
+        $destinationMockJobs = [
+            [
+                Config::PROJECT_RESTORE_COMPONENT,
+                [
+                    'parameters' => array_merge(
+                        $absCredentials,
+                        [
+                            'useDefaultBackend' => true,
+                            'restoreConfigs' => true,
+                            'dryRun' => false,
+                            'restorePermanentFiles' => true,
+                            'restoreTriggers' => true,
+                            'restoreNotifications' => true,
+                            'restoreBuckets' => true,
+                            'restoreTables' => true,
+                            'restoreProjectMetadata' => true,
+                            'checkEmptyProject' => true,
+                            'forcePrimaryKeyNotNull' => true,
+                            'tableParallelism' => 8,
+                        ],
+                    ),
+                ],
+            ],
+            [
+                Config::DATA_OF_TABLES_MIGRATE_COMPONENT,
+                [
+                    'parameters' => [
+                        'mode' => 'sapi',
+                        'sourceKbcUrl' => $sourceProjectUrl,
+                        '#sourceKbcToken' => $sourceProjectToken,
+                        'dryRun' => false,
+                        'isSourceByodb' => false,
+                        'sourceByodb' => '',
+                        'includeWorkspaceSchemas' => [],
+                        'preserveTimestamp' => false,
+                        'forcePrimaryKeyNotNull' => true,
+                        'gcsLargeTable' => [
+                            'parallelChunks' => 10,
+                            'chunkSize' => 200,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                Config::SNOWFLAKE_WRITER_MIGRATE_COMPONENT,
+                [
+                    'parameters' => [
+                        'sourceKbcUrl' => $sourceProjectUrl,
+                        '#sourceKbcToken' => $sourceProjectToken,
+                        'dryRun' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        $destJobRunnerMock->expects($this->exactly(3))
+            ->method('runJob')
+            ->withConsecutive(...$destinationMockJobs)
+            ->willReturn(Job::fromApiResponse([
+                'id' => '222',
+                'runId' => 'run-123',
+                'parentRunId' => 'parent-123',
+                'project' => ['id' => '123'],
+                'token' => ['id' => 'token-123', 'description' => null],
+                'status' => 'success',
+                'desiredStatus' => 'processing',
+                'mode' => 'run',
+                'component' => 'test-component',
+                'config' => null,
+                'configData' => null,
+                'configRowIds' => null,
+                'tag' => null,
+                'createdTime' => '2024-01-01T00:00:00+00:00',
+                'startTime' => '2024-01-01T00:00:00+00:00',
+                'endTime' => '2024-01-01T00:00:00+00:00',
+                'durationSeconds' => null,
+                'result' => null,
+                'usageData' => null,
+                'isFinished' => true,
+                'url' => 'https://example.com',
+                'branchId' => null,
+                'variableValuesId' => null,
+                'variableValuesData' => [],
+                'backend' => [],
+                'executor' => null,
+                'metrics' => null,
+                'behavior' => [],
+                'parallelism' => null,
+                'type' => 'container',
+                'orchestrationJobId' => null,
+                'orchestrationTaskId' => null,
+                'onlyOrchestrationTaskIds' => null,
+                'previousJobId' => null,
+            ]));
+
+        $config = new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => $sourceProjectUrl,
+                    '#sourceKbcToken' => $sourceProjectToken,
+                    'migrateSecrets' => false,
+                    'directDataMigration' => true,
+                    'forcePrimaryKeyNotNull' => true,
+                    'tableParallelism' => 8,
+                    'gcsLargeTable' => [
+                        'parallelChunks' => 10,
+                        'chunkSize' => 200,
+                    ],
+                ],
+            ],
+            new ConfigDefinition(),
+        );
+
+        /** @var StorageClient&MockObject $sourceClientMock */
+        $sourceClientMock = $this->createMock(StorageClient::class);
+        $sourceClientMock
+            ->method('apiGet')
+            ->willReturnMap([
+                ['dev-branches/', null, [], [['id' => '123', 'name' => 'default', 'isDefault' => true]]],
+                ['branch/default/components?include=', null, [], []],
+            ]);
+        $sourceClientMock->method('getServiceUrl')->with('encryption')->willReturn('https://encryption.keboola.com');
+        $sourceClientMock->method('generateId')->willReturn('123');
+
+        $destClientMock = $this->createDestClientMock();
+
+        /** @var Migrations&MockObject $migrationsClientMock */
+        $migrationsClientMock = $this->createMock(Migrations::class);
+        $migrationsClientMock->expects(self::never())->method('migrateConfiguration');
+
+        $migrate = new Migrate(
+            $config,
+            $sourceJobRunnerMock,
+            $destJobRunnerMock,
+            $sourceClientMock,
+            $destClientMock,
+            $migrationsClientMock,
+            'https://dest-stack/',
+            'dest-token',
+            new NullLogger(),
+        );
+
+        $migrate->run();
+    }
+
     public function testMigrateSecretsSuccess(): void
     {
         /** @var JobRunner&MockObject $sourceJobRunnerMock */


### PR DESCRIPTION
## Summary

- Add `forcePrimaryKeyNotNull` (bool, default `false`) — propagated to both `app-project-restore` and `app-project-migrate-large-tables`
- Add `tableParallelism` (int, default `5`) — always propagated to `app-project-restore`
- Add `gcsLargeTable.parallelChunks` (int, default `3`, max `20`) and `gcsLargeTable.chunkSize` (int, default `150`) — propagated to `app-project-migrate-large-tables`

## Test plan

- [x] `composer phpcs` passes
- [x] `composer phpstan` passes
- [x] `composer tests-phpunit` passes (120 tests)
- [x] New unit tests for default values, custom values, and `parallelChunks` max validation