### PR TITLE
[AJDA-2577] Add architectural documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,67 +1,142 @@
-# CLAUDE.md
+# app-project-migrate – AI Development Context
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+## What this repository does
 
-## Project Overview
+This is the **master orchestrator** for migrating Keboola projects. It moves an entire project from one stack to another (e.g. AWS US → GCP EU). It does not move data directly – it enqueues and coordinates jobs in other Keboola components via Queue API v2.
 
-App Project Migrate is a Keboola Connection orchestration application that migrates projects between stacks (e.g., US to EU). It coordinates multiple specialized migration applications to transfer configurations, data, secrets, and infrastructure.
+## Documentation
 
-The application runs in the **destination** project and reads from the **source** project (which remains unchanged).
+- **`docs/overview.md`** – brief overview + links to other docs
+- **`docs/architecture.md`** – full system architecture, all pipeline phases, what is migrated, what is skipped
+- **`docs/configuration.md`** – complete configuration parameter reference with examples
 
-## Build & Test Commands
+## Required environment variables
+
+Before running tests, verify that these variables are present in `.env` (or exported in the shell). If missing, ask for them explicitly.
+
+**Required to run tests:**
+
+| Variable | Description |
+|---|---|
+| `KBC_URL` | URL of the destination Keboola project (e.g. `https://connection.keboola.com`) |
+| `KBC_TOKEN` | Storage token of the destination project (must have admin permissions) |
+
+**Required for functional tests:**
+
+| Variable | Description |
+|---|---|
+| `SOURCE_PROJECT_URL` | URL of the source project |
+| `SOURCE_STORAGE_API_ADMIN_TOKEN` | Admin token of the source project |
+
+**Required for specific unit tests:**
+
+| Variable | Description |
+|---|---|
+| `KBC_TOKEN_NOT_MASTER` | Token without master permissions – tests rejection of unauthorized access |
+
+**Platform-injected (automatically set by Keboola Runner):**
+
+| Variable | Description |
+|---|---|
+| `KBC_RUNID` | Job run ID, used to link sub-jobs in `QueueV2JobRunner` |
+
+> Variables are passed into the Docker container via `docker compose` (file `docker-compose.yml` in the repo root). Check that the `.env` file exists in the repo root – if not, create it based on the list above.
+
+## Development commands
 
 ```bash
-# Full build pipeline (lint → phpcs → phpstan → tests)
-composer build
+composer build                 # lint → phpcs → phpstan → tests
+composer tests                 # tests-phpunit + tests-datadir
+composer tests-phpunit         # unit tests
+composer tests-datadir         # functional tests
+composer phpstan               # static analysis
+composer phpcs                 # code style
+composer phpcbf                # auto-fix code style
 
-# Individual commands
-composer tests              # Run all tests (phpunit + datadir)
-composer tests-phpunit      # Unit tests only (tests/phpunit/)
-composer tests-datadir      # Functional tests only (tests/functional/)
-composer phpstan            # Static analysis (max level)
-composer phpcs              # Code style check
-composer phpcbf             # Auto-fix code style
-
-# Docker development
-docker-compose build
-docker-compose run --rm dev composer install --no-scripts
-docker-compose run --rm dev composer tests
+# via Docker (preferred) – service name in docker-compose.yml is `dev`
+docker compose run --rm dev composer phpcs
+docker compose run --rm dev composer phpstan
+docker compose run --rm dev composer tests
 ```
 
-## Architecture
+## Key files
 
-### Core Flow
+| File | Purpose |
+|---|---|
+| `src/Migrate.php` | Pipeline logic – most important file in the repository |
+| `src/Config.php` | Configuration getters (~50 methods) |
+| `src/ConfigDefinition.php` | Parameter validation and default values |
+| `src/Component.php` | Entry point; initializes both JobRunners, validates tokens |
+| `src/JobRunner/JobRunner.php` | Interface for running jobs |
+| `src/JobRunner/JobRunnerFactory.php` | Factory for JobRunner (source vs. destination) |
+| `src/JobRunner/QueueV2JobRunner.php` | Enqueues jobs and waits for completion |
+| `src/Migrator/DataGatewayMigrator.php` | Recreates Data Gateway workspaces |
+| `src/Checker/AfterMigration.php` | Post-migration row count check |
+| `src/Utils.php` | `checkMigrationApps()`, `checkIfProjectEmpty()` |
 
-1. **Component** (`src/Component.php`) - Entry point, validates tokens and project state
-2. **Migrate** (`src/Migrate.php`) - Orchestrates migration steps in sequence
-3. **JobRunner** - Executes jobs via appropriate queue system (QueueV2 or legacy Syrup)
-4. **AfterMigration** (`src/Checker/AfterMigration.php`) - Post-migration validation
+## Pipeline phases (src/Migrate.php)
 
-### Migration Steps (in order)
+| Phase | What runs | Condition |
+|---|---|---|
+| 1. Backup | `keboola.project-backup` via `sourceJobRunner` | always |
+| 2. Credentials | sync action `generate-read-credentials` | always |
+| 3. Restore | `keboola.project-restore` via `destJobRunner` | `migrateBuckets`, `migrateTables`, etc. |
+| 4. Secrets | Encryption API for each configuration | `migrateSecrets: true` |
+| 5. Table data | `keboola.app-project-migrate-large-tables` | `migrateBuckets && migrateTables && directDataMigration && !migrateStructureOnly` |
+| 6. Snowflake Writers | `keboola.app-snowflake-writer-migrate` | `!migrateSecrets` |
+| 7. Data Gateway | `DataGatewayMigrator` direct API calls | `migrateDataGateway: true` |
+| 8. Post-check | `AfterMigration` row count comparison | always |
 
-1. Backup source project (keboola.project-backup)
-2. Restore to destination (keboola.project-restore)
-3. Migrate secrets/configs via encryption-api (if enabled)
-4. Migrate table data directly (keboola.app-project-migrate-large-tables)
-5. Migrate Snowflake writers and Orchestrators (dedicated apps)
+## What is skipped and why
 
-### Key Patterns
+### Components skipped during restore (Phase 3)
 
-- **JobRunner Factory**: Creates QueueV2JobRunner or SyrupJobRunner based on project features
-- **Configuration**: ConfigDefinition uses Symfony Config for validation; secrets prefixed with `#`
-- **Data Modes**: `sapi` (API-based transfer) or `database` (direct DB replication)
+These components are skipped by `app-project-restore` – they are handled elsewhere:
 
-### Configuration Parameters
+```
+'orchestrator'                      // Orchestrator Migrate App (outside this system)
+'gooddata-writer'                   // GoodData Writer Migrate App (outside this system)
+'keboola.wr-db-snowflake'          // Phase 6 (app-snowflake-writer-migrate)
+'keboola.wr-snowflake-blob-storage' // Phase 6
+'keboola.wr-db-snowflake-gcs'      // Phase 6
+'keboola.wr-db-snowflake-gcs-s3'   // Phase 6
+```
 
-Required: `sourceKbcUrl`, `#sourceKbcToken`
-Optional: `migrateSecrets`, `migrateBuckets`, `migrateTables`, `dryRun`, `dataMode`, etc.
+Orchestrator configurations are restored but automatically set to `isDisabled: true`.
 
-When `migrateSecrets=true`: requires `#sourceManageToken`
-When `dataMode=database`: requires `db` object with credentials
+## dataMode: database (Snowflake replication)
 
-## Code Standards
+Mode `database` bypasses Storage API and uses native Snowflake replication. Significantly faster for large Snowflake-to-Snowflake migrations.
 
-- PHP 7.4 with strict types
+Predefined stack-to-Snowflake-account mappings are in `app-project-migrate-tables-data/src/Config.php`.
+
+For other stacks or BYODB: `isSourceByodb: true` + `sourceByodb: <db_name>`.
+
+## GCS large tables
+
+Tables on GCP stacks that are sliced and >50 GB are migrated using parallel worker processes (`worker-chunk.php`) in `app-project-migrate-tables-data`. Number of workers: `gcsLargeTable.parallelChunks` (default 3, max 20).
+
+## JobRunner and componentsDevTag
+
+`QueueV2JobRunner` enqueues jobs and polls for completion. `componentsDevTag.*` parameters allow overriding the Docker image tag of sub-components – useful for testing a dev branch without releasing.
+
+## Data Gateway
+
+`DataGatewayMigrator` recreates a workspace for each unique source schema (RSA 2048-bit keypair). **Data in Data Gateway workspaces is NOT migrated** – the user must manually reload source data.
+
+## Coding standards
+
+- PHP 8.x with strict types
 - PHPStan level max
-- Keboola coding standard (PSR-12 based)
-- UserException for user-actionable errors
+- Keboola coding standard (PSR-12)
+- `UserException` for user-visible errors (displayed in Keboola UI)
+- `ApplicationException` for internal/unexpected errors
+
+## Related repositories
+
+| Component ID | Repository |
+|---|---|
+| `keboola.project-backup` | `app-project-backup` → `php-kbc-project-backup` |
+| `keboola.project-restore` | `app-project-restore` → `php-kbc-project-restore` |
+| `keboola.app-project-migrate-large-tables` | `app-project-migrate-tables-data` |
+| `keboola.app-snowflake-writer-migrate` | `app-snowflake-writer-migrate` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,221 @@
+# Migration system architecture – overview
+
+## What the system does
+
+The system allows moving an entire Keboola project from one stack to another (e.g. AWS US → GCP EU). It migrates component configurations, storage structure (buckets, tables), table data, triggers, notifications, permanent files, and encrypted secrets.
+
+## Repositories
+
+The system consists of 7 PHP repositories in two layers:
+
+### PHP libraries (low-level logic)
+
+| Repository | Role |
+|---|---|
+| `php-kbc-project-backup` | Backup project to cloud storage (S3/ABS/GCS) |
+| `php-kbc-project-restore` | Restore project from cloud storage |
+
+### Keboola App components (runnable as Keboola jobs)
+
+| Repository | Component ID | Role |
+|---|---|---|
+| `app-project-backup` | `keboola.project-backup` | Backup wrapper |
+| `app-project-restore` | `keboola.project-restore` | Restore wrapper |
+| `app-project-migrate` | *(master orchestrator)* | Controls the entire pipeline |
+| `app-project-migrate-tables-data` | `keboola.app-project-migrate-large-tables` | Direct table data migration |
+| `app-snowflake-writer-migrate` | `keboola.app-snowflake-writer-migrate` | Snowflake Writer configuration migration |
+
+## Pipeline
+
+`app-project-migrate` is the entry point. It orchestrates other components via Keboola Queue API v2.
+
+```
+app-project-migrate
+ │
+ ├─ PHASE 1 ──── Backup source project
+ │               Runs: app-project-backup (keboola.project-backup)
+ │               Where: source project (sourceJobRunner)
+ │
+ ├─ PHASE 2 ──── Obtain backup access credentials
+ │               Sync action: generate-read-credentials on app-project-backup
+ │
+ ├─ PHASE 3 ──── Restore structure in destination project
+ │               Runs: app-project-restore (keboola.project-restore)
+ │               Where: destination project (destJobRunner)
+ │
+ ├─ PHASE 4 ──── Migrate encrypted secrets [optional, migrateSecrets: true]
+ │               Calls Encryption API directly for each configuration
+ │
+ ├─ PHASE 5 ──── Direct table data migration
+ │               Conditions: migrateBuckets: true AND migrateTables: true
+ │                          AND directDataMigration: true AND migrateStructureOnly: false
+ │               Runs: app-project-migrate-tables-data
+ │               Where: destination project (destJobRunner)
+ │
+ ├─ PHASE 6 ──── Migrate Snowflake Writers [if migrateSecrets: false]
+ │               Runs: app-snowflake-writer-migrate
+ │               Where: destination project (destJobRunner)
+ │
+ ├─ PHASE 7 ──── Migrate Data Gateway [optional, migrateDataGateway: true]
+ │               DataGatewayMigrator – direct API calls
+ │
+ └─ PHASE 8 ──── Post-migration check
+                AfterMigration – row count comparison
+```
+
+## Phase details
+
+### Phase 1 + 2 – Backup
+
+`app-project-backup` wraps `php-kbc-project-backup` and saves the backup to cloud storage.
+
+**What is backed up:**
+- Project metadata (default branch)
+- Bucket and table definitions including column metadata
+- Table data (gzip CSV or sliced files) – **see note below**
+- All component configurations (including versions if `includeVersions: true`)
+- Permanent files
+- Triggers and notifications
+
+> **Optimization:** When `directDataMigration: true` (default) or `migrateStructureOnly: true`, Phase 1 runs with `exportStructureOnly: true` – **table data is not backed up**, only structure. Data flows directly through Phase 5. This makes Phase 1 fast even for large projects.
+
+**What is skipped:**
+- Sys bucket tables
+- Alias tables
+- External schema tables
+- Data Catalog tables (have `sourceBucket`)
+
+After the backup, the sync action `generate-read-credentials` is called, which returns temporary read-only credentials for Phase 3. This allows the destination project to access the backup without sharing long-lived credentials.
+
+### Phase 3 – Restore
+
+`app-project-restore` wraps `php-kbc-project-restore` and restores the project structure.
+
+**Sequence:**
+1. Project metadata
+2. Buckets
+3. Component configurations (except those with special restore handling)
+4. Tables (in parallel, worker scripts)
+5. Alias tables
+6. Triggers, notifications, files
+
+> **Note:** If `migrateSecrets: true`, step 3 (configurations) is intentionally **skipped** (`restoreConfigs: false`). Configurations with encrypted secrets arrive complete via Encryption API in Phase 4. Without this, they would first be restored without secrets and then overwritten – unnecessary double SAPI calls.
+
+**Skipped components** – must be migrated differently:
+
+| Component ID | Where migrated |
+|---|---|
+| `orchestrator` | Orchestrator Migrate App (outside this system) |
+| `gooddata-writer` | GoodData Writer Migrate App (outside this system) |
+| `keboola.wr-db-snowflake` | Phase 6 (app-snowflake-writer-migrate) |
+| `keboola.wr-snowflake-blob-storage` | Phase 6 |
+| `keboola.wr-db-snowflake-gcs` | Phase 6 |
+| `keboola.wr-db-snowflake-gcs-s3` | Phase 6 |
+
+`keboola.orchestrator` configurations are restored but automatically set to `isDisabled: true`. Users must manually re-enable orchestrations after verifying the migration.
+
+Tables are created in parallel using `symfony/process` worker scripts (`worker-create-table.php`). The number of parallel processes is controlled by `tableParallelism` (default: 5 in migrate, 10 in standalone restore).
+
+### Phase 4 – Secrets migration
+
+Calls Keboola Encryption API (`MigrationsClient::migrateConfiguration()`) for each configuration from the source project. Requires `#sourceManageToken`.
+
+Skips: `orchestrator`, `gooddata-writer`.
+
+For Snowflake Writers, additionally calls `preserveProperSnowflakeWorkspace()` – ensures consistent workspace reuse across multiple configurations of the same writer.
+
+If `migrateSecrets: false` (default), encrypted secrets are **not migrated** and must be manually set in the destination. In this case, Snowflake Writers are handled by Phase 6.
+
+### Phase 5 – Table data migration
+
+Managed by `app-project-migrate-tables-data`. Has two modes:
+
+**Mode `sapi` (default):** Export from source → upload to SAPI file storage → import to destination.
+
+For large GCS tables (sliced + >50 GB), a parallel worker approach is used:
+- Manifest is split into chunks (`gcsLargeTable.chunkSize` slices, default 150)
+- Up to `gcsLargeTable.parallelChunks` (default 3, max 20) worker processes run in parallel
+- Each worker (`worker-chunk.php`) downloads its chunk from GCS and uploads to SAPI
+- Import to destination table happens incrementally
+- PK is removed before import and restored after completion
+
+**Mode `database`:** Direct Snowflake replication without going through Storage API – significantly faster for large data (see section below).
+
+### Phase 6 – Snowflake Writers
+
+`app-snowflake-writer-migrate` creates a new configuration for each Snowflake Writer. For Keboola-provisioned writers, it creates a workspace in the destination project, encrypts the password via Encryption API, and copies configurations and rows.
+
+### Phase 7 – Data Gateway
+
+`DataGatewayMigrator` iterates through all Data Gateway configurations in the destination project (restored in Phase 3, but without credentials) and creates a new workspace with an RSA keypair for each unique source schema.
+
+**Note:** Data in Data Gateway workspaces is **not migrated**. Users must manually reload source data.
+
+### Phase 8 – Post-migration check
+
+`AfterMigration` compares row counts of all tables between source and destination. If they do not match, throws a `UserException`.
+
+## Controlling individual migration parts
+
+All optional phases can be controlled by parameters in `app-project-migrate`:
+
+| Parameter | Default | Controls |
+|---|---|---|
+| `migrateProjectMetadata` | `true` | Phase 3: project metadata |
+| `migrateBuckets` | `true` | Phase 3: buckets |
+| `migrateTables` | `true` | Phase 3: tables (structure) |
+| `migrateStructureOnly` | `false` | Phase 3: skips table data |
+| `migratePermanentFiles` | `true` | Phase 3: permanent files |
+| `migrateTriggers` | `true` | Phase 3: triggers |
+| `migrateNotifications` | `true` | Phase 3: notifications |
+| `migrateSecrets` | `false` | Phase 4: encrypted secrets |
+| `directDataMigration` | `true` | Phase 5: direct data migration |
+| `migrateDataGateway` | `true` | Phase 7: Data Gateway |
+| `checkEmptyProject` | `true` | Refuses to start migration into a non-empty project |
+| `dryRun` | `false` | Simulates the entire pipeline without actual changes |
+
+## Parallel migration to GCP stacks
+
+GCP stacks use GCS as the storage backend. Large tables (>50 GB, sliced) are migrated in a special way in `app-project-migrate-tables-data`:
+
+1. File manifest is downloaded from GCS
+2. Entries (slices) are split into chunks of `gcsLargeTable.chunkSize` (default 150)
+3. Parallel worker processes (`worker-chunk.php`) are started – max `gcsLargeTable.parallelChunks` (default 3, max 20)
+4. Each worker downloads its chunk from GCS, uploads to SAPI file storage and returns `fileId`
+5. Import happens incrementally, PK is temporarily removed and restored after import
+
+For Snowflake-to-Snowflake migrations to GCP stacks, **database mode** with direct Snowflake replication is also available (see `app-project-migrate-tables-data` documentation).
+
+## Cloud storage backends
+
+| Backend | Authentication |
+|---|---|
+| AWS S3 | `access_key_id` + `#secret_access_key` |
+| Azure Blob Storage | `accountName` + `#accountKey` |
+| GCS | `#jsonKey` (service account JSON) |
+
+## Dependency graph
+
+```
+app-project-migrate
+  ├─ keboola/storage-api-client
+  ├─ keboola/job-queue-api-php-client
+  ├─ keboola/sync-actions-client
+  ├─ keboola/encryption-api-php-client
+  └─ keboola/php-component
+
+app-project-backup → php-kbc-project-backup
+  └─ cloud SDKs (aws/google/azure)
+
+app-project-restore → php-kbc-project-restore
+  ├─ cloud SDKs
+  └─ symfony/process (worker-create-table.php)
+
+app-project-migrate-tables-data
+  ├─ keboola/storage-api-client
+  ├─ keboola/db-adapter-snowflake
+  └─ symfony/process (worker-chunk.php)
+
+app-snowflake-writer-migrate
+  └─ keboola/storage-api-client
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,7 @@
 
 | Parameter | Description |
 |---|---|
+| `sourceKbcUrl` | URL of the source stack (required by configuration validation; defaults to `https://connection.keboola.com`) |
 | `#sourceKbcToken` | Storage token of the source Keboola project |
 
 `#sourceManageToken` is additionally required if `migrateSecrets: true`.
@@ -57,20 +58,20 @@ Applies only to sliced tables larger than 50 GB on GCP stacks.
 | Parameter | Default | Limits | Description |
 |---|---|---|---|
 | `gcsLargeTable.parallelChunks` | `3` | 1–20 | Number of parallel worker processes |
-| `gcsLargeTable.chunkSize` | `150` | min 1 | Number of GCS slices per chunk |
+| `gcsLargeTable.chunkSize` | `150` | min 1 | Size of each chunk in MB |
 
 ## Database mode (`dataMode: database`)
 
-Required if `dataMode: database`. Forbidden if `dataMode: sapi`.
+Available only if `dataMode: database`. The `db` object is optional and is only needed for BYODB or other cases where the default Snowflake connection details must be overridden. Do not provide `db` when `dataMode: sapi`.
 
 | Parameter | Description |
 |---|---|
-| `db.host` | Snowflake host |
-| `db.username` | Snowflake username |
-| `db.#password` | Password (one of `#password` or `#privateKey` is required) |
-| `db.#privateKey` | Private key for key-pair authentication |
-| `db.warehouse` | Snowflake warehouse name |
-| `db.warehouse_size` | `SMALL` (default) / `MEDIUM` / `LARGE` |
+| `db.host` | Snowflake host override |
+| `db.username` | Snowflake username override |
+| `db.#password` | Password override (one of `#password` or `#privateKey` is required when providing `db`) |
+| `db.#privateKey` | Private key override for key-pair authentication |
+| `db.warehouse` | Snowflake warehouse name override |
+| `db.warehouse_size` | Warehouse size override: `SMALL` (default) / `MEDIUM` / `LARGE` |
 
 | Parameter | Default | Description |
 |---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,157 @@
+# Configuration parameter reference – app-project-migrate
+
+## Required parameters
+
+| Parameter | Description |
+|---|---|
+| `#sourceKbcToken` | Storage token of the source Keboola project |
+
+`#sourceManageToken` is additionally required if `migrateSecrets: true`.
+
+## Migration switches
+
+Default value is `true` unless stated otherwise.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `migrateProjectMetadata` | `true` | Restores default branch metadata |
+| `migrateBuckets` | `true` | Restores storage buckets |
+| `migrateTables` | `true` | Creates table structures |
+| `migrateStructureOnly` | `false` | If `true`, skips table data migration (structure only) |
+| `migratePermanentFiles` | `true` | Restores permanent files |
+| `migrateTriggers` | `true` | Restores flow triggers |
+| `migrateNotifications` | `true` | Restores notification subscriptions |
+| `migrateSecrets` | `false` | Re-encrypts secrets via Encryption API (requires `#sourceManageToken`) |
+| `directDataMigration` | `true` | Runs direct table data migration (Phase 5) |
+| `migrateDataGateway` | `true` | Recreates Data Gateway workspaces |
+
+## Safety switches
+
+| Parameter | Default | Description |
+|---|---|---|
+| `checkEmptyProject` | `true` | Rejects migration into a non-empty destination project |
+| `dryRun` | `false` | Simulates the entire pipeline without making actual changes |
+| `skipRegionValidation` | `false` | Skips validation that project region matches storage backend region |
+
+## Source project
+
+| Parameter | Default | Description |
+|---|---|---|
+| `sourceKbcUrl` | `https://connection.keboola.com` | URL of the source stack |
+| `#sourceKbcToken` | REQUIRED | Storage token |
+| `#sourceManageToken` | – | Manage token (required only if `migrateSecrets: true`) |
+
+## Data migration options
+
+| Parameter | Default | Description |
+|---|---|---|
+| `dataMode` | `sapi` | `sapi` = via Storage API; `database` = via Snowflake replication |
+| `preserveTimestamp` | `false` | Preserves `_timestamp` column values from source data |
+| `forcePrimaryKeyNotNull` | `false` | Forces NOT NULL on primary key columns in typed tables |
+| `tableParallelism` | `5` | Number of parallel workers for table creation |
+
+## GCS large table tuning
+
+Applies only to sliced tables larger than 50 GB on GCP stacks.
+
+| Parameter | Default | Limits | Description |
+|---|---|---|---|
+| `gcsLargeTable.parallelChunks` | `3` | 1–20 | Number of parallel worker processes |
+| `gcsLargeTable.chunkSize` | `150` | min 1 | Number of GCS slices per chunk |
+
+## Database mode (`dataMode: database`)
+
+Required if `dataMode: database`. Forbidden if `dataMode: sapi`.
+
+| Parameter | Description |
+|---|---|
+| `db.host` | Snowflake host |
+| `db.username` | Snowflake username |
+| `db.#password` | Password (one of `#password` or `#privateKey` is required) |
+| `db.#privateKey` | Private key for key-pair authentication |
+| `db.warehouse` | Snowflake warehouse name |
+| `db.warehouse_size` | `SMALL` (default) / `MEDIUM` / `LARGE` |
+
+| Parameter | Default | Description |
+|---|---|---|
+| `isSourceByodb` | `false` | Source uses BYODB (non-standard Snowflake account) |
+| `sourceByodb` | – | BYODB database name |
+| `includeWorkspaceSchemas` | `[]` | Workspace schemas to include in database mode |
+
+## Dev image tags
+
+Allow testing specific Docker image tags of sub-components without releasing.
+
+| Parameter | Description |
+|---|---|
+| `componentsDevTag.backup` | Override Docker tag for `keboola.project-backup` |
+| `componentsDevTag.restore` | Override Docker tag for `keboola.project-restore` |
+| `componentsDevTag.tablesData` | Override Docker tag for `keboola.app-project-migrate-large-tables` |
+
+## Configuration examples
+
+### Minimal migration (structure only, no data)
+
+```json
+{
+  "parameters": {
+    "sourceKbcUrl": "https://connection.keboola.com",
+    "#sourceKbcToken": "xxx",
+    "migrateStructureOnly": true,
+    "directDataMigration": false
+  }
+}
+```
+
+### Full migration with secrets
+
+```json
+{
+  "parameters": {
+    "sourceKbcUrl": "https://connection.keboola.com",
+    "#sourceKbcToken": "xxx",
+    "#sourceManageToken": "yyy",
+    "migrateSecrets": true,
+    "directDataMigration": true,
+    "tableParallelism": 10,
+    "gcsLargeTable": {
+      "parallelChunks": 5,
+      "chunkSize": 200
+    }
+  }
+}
+```
+
+### Database mode (direct Snowflake replication)
+
+```json
+{
+  "parameters": {
+    "sourceKbcUrl": "https://connection.keboola.com",
+    "#sourceKbcToken": "xxx",
+    "dataMode": "database",
+    "db": {
+      "host": "keboola.snowflakecomputing.com",
+      "username": "svc_migrate",
+      "#password": "secret",
+      "warehouse": "MIGRATE_WH",
+      "warehouse_size": "MEDIUM"
+    }
+  }
+}
+```
+
+### Configurations only (no storage data)
+
+```json
+{
+  "parameters": {
+    "sourceKbcUrl": "https://connection.keboola.com",
+    "#sourceKbcToken": "xxx",
+    "migrateBuckets": false,
+    "migrateTables": false,
+    "directDataMigration": false,
+    "migratePermanentFiles": false
+  }
+}
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,8 +40,8 @@ See `architecture.md` for details on each phase.
 | `src/Config.php` | Configuration getters |
 | `src/ConfigDefinition.php` | Parameter validation |
 | `src/JobRunner/` | Job execution via Queue API v2 |
-| `src/DataGatewayMigrator.php` | Phase 7 |
-| `src/AfterMigration.php` | Phase 8 |
+| `src/Migrator/DataGatewayMigrator.php` | Phase 7 |
+| `src/Checker/AfterMigration.php` | Phase 8 |
 
 ## Related repositories
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,49 @@
+# app-project-migrate – overview
+
+## What the component does
+
+This is the **master orchestrator** for migrating Keboola projects between stacks (e.g. AWS US → GCP EU). It does not move data directly – it enqueues and coordinates jobs in other Keboola components via Queue API v2.
+
+Component ID: `keboola.app-project-migrate` (does not run itself via `app-project-migrate`).
+
+## Further reading
+
+This component is extensive and its documentation is split into several files:
+
+| Document | Contents |
+|---|---|
+| [`architecture.md`](architecture.md) | Full system architecture, all pipeline phases, what is migrated, what is skipped, dependency graph |
+| [`configuration.md`](configuration.md) | Complete configuration parameter reference with examples |
+| [`../CLAUDE.md`](../CLAUDE.md) | AI development context, env variables, commands |
+
+## Pipeline quick reference
+
+```
+PHASE 1 – Backup source project          (app-project-backup)
+PHASE 2 – Obtain read credentials        (sync action)
+PHASE 3 – Restore structure in target    (app-project-restore)
+PHASE 4 – Migrate secrets                [optional, Encryption API]
+PHASE 5 – Direct table data migration    [optional, app-project-migrate-tables-data]
+PHASE 6 – Migrate Snowflake Writers      (app-snowflake-writer-migrate)
+PHASE 7 – Migrate Data Gateway           [optional]
+PHASE 8 – Post-migration check           (row count comparison)
+```
+
+See `architecture.md` for details on each phase.
+
+## Key files
+
+| File | Description |
+|---|---|
+| `src/Component.php` | Entry point |
+| `src/Migrate.php` | Orchestrates all 8 pipeline phases |
+| `src/Config.php` | Configuration getters |
+| `src/ConfigDefinition.php` | Parameter validation |
+| `src/JobRunner/` | Job execution via Queue API v2 |
+| `src/DataGatewayMigrator.php` | Phase 7 |
+| `src/AfterMigration.php` | Phase 8 |
+
+## Related repositories
+
+- Runs: `app-project-backup`, `app-project-restore`, `app-project-migrate-tables-data`, `app-snowflake-writer-migrate`
+- Libraries (indirect): `php-kbc-project-backup`, `php-kbc-project-restore`


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with AI development context, required environment variables, key files and development commands
- Add `docs/overview.md` with quick reference and links to detailed docs
- Add `docs/architecture.md` covering all 8 pipeline phases, migration switches, GCS parallel migration and Snowflake database mode
- Add `docs/configuration.md` with complete parameter reference and configuration examples