### PR TITLE
[AJDA-2881] Integrate Snowflake Replication Group strategy in Phase 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ The request contains the following parameters:
 - `gcsLargeTable`: Configuration for GCS large table migration (propagated to `app-project-migrate-large-tables`):
   - `parallelChunks`: Number of parallel chunks to use during GCS table migration (default: `3`, max: `20`)
   - `chunkSize`: Size of each chunk in MB during GCS table migration (default: `150`)
+- `replicationStrategy`: Snowflake replication strategy for `dataMode: database` (default: `standalone`). `standalone` creates and drops its own replica per run; `group` reuses a pre-created shared Replication Group. Propagated to `app-project-migrate-large-tables`.
+- `replicationGroup`: Replication group settings (used only when `replicationStrategy: group`):
+  - `name`: Name of the primary replication group (required when `replicationStrategy: group`; must match the group created manually). The shared group is NOT dropped per run — teardown is a separate manual / ops step.
 - `componentsDevTag`: Object with dev branch tags for migration components:
   - `backup`: Dev tag for the backup component
   - `restore`: Dev tag for the restore component

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,22 @@ Applies only to sliced tables larger than 50 GB on GCP stacks.
 | `gcsLargeTable.parallelChunks` | `3` | 1–20 | Number of parallel worker processes |
 | `gcsLargeTable.chunkSize` | `150` | min 1 | Size of each chunk in MB |
 
+## Snowflake replication strategy
+
+Applies only to `dataMode: database`. Selects how the destination Snowflake replica is provisioned
+during Phase 5 (`keboola.app-project-migrate-large-tables`).
+
+| Parameter | Default | Values | Description |
+|---|---|---|---|
+| `replicationStrategy` | `standalone` | `standalone` / `group` | `standalone` creates and drops its own replica per run. `group` reuses a pre-created shared **Replication Group**. |
+| `replicationGroup.name` | – | – | Name of the primary replication group. **Required when `replicationStrategy: group`.** Must match the group created manually during the ops step. |
+
+**Drop behavior:**
+- `standalone` — the per-project run tears down its own replica (component default `replica.drop = true`).
+- `group` — the shared replication group is NOT dropped per run (component default `replica.drop = false`). Group teardown (`DROP REPLICATION GROUP`) is a separate manual / ops step.
+
+Creating the primary replication group on the source is a manual / ops step performed before running the orchestrator. The orchestrator passes no `replica` flags; it relies on the component's `replica.*` defaults.
+
 ## Database mode (`dataMode: database`)
 
 Available only if `dataMode: database`. The `db` object is optional and is only needed for BYODB or other cases where the default Snowflake connection details must be overridden. Do not provide `db` when `dataMode: sapi`.

--- a/src/Config.php
+++ b/src/Config.php
@@ -170,7 +170,11 @@ class Config extends BaseConfig
         } catch (InvalidArgumentException) {
             return null;
         }
-        return is_string($value) && $value !== '' ? $value : null;
+        if (!is_string($value)) {
+            return null;
+        }
+        $value = trim($value);
+        return $value !== '' ? $value : null;
     }
 
     public function checkEmptyProject(): bool

--- a/src/Config.php
+++ b/src/Config.php
@@ -157,6 +157,22 @@ class Config extends BaseConfig
         return $this->getIntValue(['parameters', 'gcsLargeTable', 'chunkSize'], 150);
     }
 
+    public function getReplicationStrategy(): string
+    {
+        return $this->getStringValue(['parameters', 'replicationStrategy'], 'standalone');
+    }
+
+    public function getReplicationGroupName(): ?string
+    {
+        try {
+            /** @var string|null $value */
+            $value = $this->getValue(['parameters', 'replicationGroup', 'name']);
+        } catch (InvalidArgumentException) {
+            return null;
+        }
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
     public function checkEmptyProject(): bool
     {
         return $this->getBoolValue(['parameters', 'checkEmptyProject']);

--- a/src/Config.php
+++ b/src/Config.php
@@ -165,16 +165,14 @@ class Config extends BaseConfig
     public function getReplicationGroupName(): ?string
     {
         try {
+            // Non-empty validation lives in ConfigDefinition; here we only read the value
+            // (it is absent in standalone mode, where getValue() throws).
             /** @var string|null $value */
             $value = $this->getValue(['parameters', 'replicationGroup', 'name']);
         } catch (InvalidArgumentException) {
             return null;
         }
-        if (!is_string($value)) {
-            return null;
-        }
-        $value = trim($value);
-        return $value !== '' ? $value : null;
+        return is_string($value) ? $value : null;
     }
 
     public function checkEmptyProject(): bool

--- a/src/ConfigDefinition.php
+++ b/src/ConfigDefinition.php
@@ -132,8 +132,13 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->thenInvalid('Parameter "db" is allowed only when "dataMode" is set to "database".')
             ->end()
             ->validate()
-                ->ifTrue(fn($values) => ($values['replicationStrategy'] ?? 'standalone') === 'group'
-                    && empty($values['replicationGroup']['name']))
+                ->ifTrue(function ($values): bool {
+                    if (($values['replicationStrategy'] ?? 'standalone') !== 'group') {
+                        return false;
+                    }
+                    $name = $values['replicationGroup']['name'] ?? null;
+                    return !is_string($name) || trim($name) === '';
+                })
                 ->thenInvalid(
                     'Parameter "replicationGroup.name" is required when "replicationStrategy" is set to "group".',
                 )

--- a/src/ConfigDefinition.php
+++ b/src/ConfigDefinition.php
@@ -82,6 +82,15 @@ class ConfigDefinition extends BaseConfigDefinition
                         ->end()
                     ->end()
                 ->end()
+                ->enumNode('replicationStrategy')
+                    ->values(['standalone', 'group'])
+                    ->defaultValue('standalone')
+                ->end()
+                ->arrayNode('replicationGroup')
+                    ->children()
+                        ->scalarNode('name')->end()
+                    ->end()
+                ->end()
                 ->arrayNode('componentsDevTag')
                     ->children()
                         ->scalarNode('backup')->end()
@@ -121,6 +130,13 @@ class ConfigDefinition extends BaseConfigDefinition
             ->validate()
                 ->ifTrue(fn($values) => $values['dataMode'] === 'sapi' && isset($values['db']))
                 ->thenInvalid('Parameter "db" is allowed only when "dataMode" is set to "database".')
+            ->end()
+            ->validate()
+                ->ifTrue(fn($values) => ($values['replicationStrategy'] ?? 'standalone') === 'group'
+                    && empty($values['replicationGroup']['name']))
+                ->thenInvalid(
+                    'Parameter "replicationGroup.name" is required when "replicationStrategy" is set to "group".',
+                )
             ->end()
         ->end();
         return $parametersNode;

--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -265,16 +265,18 @@ class Migrate
                 'parallelChunks' => $this->config->getGcsLargeTableParallelChunks(),
                 'chunkSize' => $this->config->getGcsLargeTableChunkSize(),
             ],
-            'replicationStrategy' => $this->config->getReplicationStrategy(),
         ];
 
-        if ($this->config->getReplicationStrategy() === 'group') {
-            $parameters['replicationGroup'] = [
-                'name' => $this->config->getReplicationGroupName(),
-            ];
-        }
-
+        // Replication is a database-mode concept (Snowflake replica); not applicable in sapi mode.
         if ($this->config->getMigrateDataMode() === 'database') {
+            $parameters['replicationStrategy'] = $this->config->getReplicationStrategy();
+
+            if ($this->config->getReplicationStrategy() === 'group') {
+                $parameters['replicationGroup'] = [
+                    'name' => $this->config->getReplicationGroupName(),
+                ];
+            }
+
             $db = $this->config->getDb();
             if (isset($db['host'])) {
                 $parameters['db'] = $db;

--- a/src/Migrate.php
+++ b/src/Migrate.php
@@ -265,7 +265,14 @@ class Migrate
                 'parallelChunks' => $this->config->getGcsLargeTableParallelChunks(),
                 'chunkSize' => $this->config->getGcsLargeTableChunkSize(),
             ],
+            'replicationStrategy' => $this->config->getReplicationStrategy(),
         ];
+
+        if ($this->config->getReplicationStrategy() === 'group') {
+            $parameters['replicationGroup'] = [
+                'name' => $this->config->getReplicationGroupName(),
+            ];
+        }
 
         if ($this->config->getMigrateDataMode() === 'database') {
             $db = $this->config->getDb();

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -104,6 +104,14 @@ class ConfigTest extends TestCase
             'Parameter "replicationGroup.name" is required when "replicationStrategy" is set to "group".',
         ];
 
+        yield 'replicationStrategy group with whitespace-only group name' => [
+            [
+                'replicationStrategy' => 'group',
+                'replicationGroup' => ['name' => '   '],
+            ],
+            'Parameter "replicationGroup.name" is required when "replicationStrategy" is set to "group".',
+        ];
+
         yield 'invalid replicationStrategy value' => [
             ['replicationStrategy' => 'invalid'],
             'The value "invalid" is not allowed for path "root.parameters.replicationStrategy"',

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -90,6 +90,24 @@ class ConfigTest extends TestCase
             ['gcsLargeTable' => ['chunkSize' => -1]],
             'gcsLargeTable.chunkSize must be at least 1.',
         ];
+
+        yield 'replicationStrategy group without group name' => [
+            ['replicationStrategy' => 'group'],
+            'Parameter "replicationGroup.name" is required when "replicationStrategy" is set to "group".',
+        ];
+
+        yield 'replicationStrategy group with empty group name' => [
+            [
+                'replicationStrategy' => 'group',
+                'replicationGroup' => ['name' => ''],
+            ],
+            'Parameter "replicationGroup.name" is required when "replicationStrategy" is set to "group".',
+        ];
+
+        yield 'invalid replicationStrategy value' => [
+            ['replicationStrategy' => 'invalid'],
+            'The value "invalid" is not allowed for path "root.parameters.replicationStrategy"',
+        ];
     }
 
     public function testMigrateSecretsConfigValid(): void
@@ -572,6 +590,76 @@ class ConfigTest extends TestCase
         self::assertSame(10, $config->getTableParallelism());
         self::assertSame(10, $config->getGcsLargeTableParallelChunks());
         self::assertSame(200, $config->getGcsLargeTableChunkSize());
+    }
+
+    public function testReplicationStrategyDefaultValue(): void
+    {
+        $config = new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => 'https://connection.keboola.com',
+                    '#sourceKbcToken' => 'token',
+                ],
+            ],
+            new ConfigDefinition(),
+        );
+
+        self::assertSame('standalone', $config->getReplicationStrategy());
+        self::assertNull($config->getReplicationGroupName());
+    }
+
+    public function testReplicationGroupCustomValues(): void
+    {
+        $config = new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => 'https://connection.keboola.com',
+                    '#sourceKbcToken' => 'token',
+                    'replicationStrategy' => 'group',
+                    'replicationGroup' => [
+                        'name' => 'MIGRATE_RG_1234',
+                    ],
+                ],
+            ],
+            new ConfigDefinition(),
+        );
+
+        self::assertSame('group', $config->getReplicationStrategy());
+        self::assertSame('MIGRATE_RG_1234', $config->getReplicationGroupName());
+    }
+
+    public function testReplicationGroupValidConfig(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => 'https://connection.keboola.com',
+                    '#sourceKbcToken' => 'token',
+                    'replicationStrategy' => 'group',
+                    'replicationGroup' => ['name' => 'MIGRATE_RG_1234'],
+                ],
+            ],
+            new ConfigDefinition(),
+        );
+    }
+
+    public function testReplicationStrategyStandaloneIgnoresGroupName(): void
+    {
+        $config = new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => 'https://connection.keboola.com',
+                    '#sourceKbcToken' => 'token',
+                    'replicationStrategy' => 'standalone',
+                ],
+            ],
+            new ConfigDefinition(),
+        );
+
+        self::assertSame('standalone', $config->getReplicationStrategy());
+        self::assertNull($config->getReplicationGroupName());
     }
 
     public function testGetSourceManageTokenDefaultValue(): void

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -172,7 +172,6 @@ class MigrateTest extends TestCase
                             'parallelChunks' => 3,
                             'chunkSize' => 150,
                         ],
-                        'replicationStrategy' => 'standalone',
                     ],
                 ],
             ];
@@ -395,7 +394,6 @@ class MigrateTest extends TestCase
                             'parallelChunks' => 10,
                             'chunkSize' => 200,
                         ],
-                        'replicationStrategy' => 'standalone',
                     ],
                 ],
             ],
@@ -552,7 +550,7 @@ class MigrateTest extends TestCase
                 Config::DATA_OF_TABLES_MIGRATE_COMPONENT,
                 [
                     'parameters' => [
-                        'mode' => 'sapi',
+                        'mode' => 'database',
                         'sourceKbcUrl' => $sourceProjectUrl,
                         '#sourceKbcToken' => $sourceProjectToken,
                         'dryRun' => false,
@@ -593,6 +591,7 @@ class MigrateTest extends TestCase
                     '#sourceKbcToken' => $sourceProjectToken,
                     'migrateSecrets' => false,
                     'directDataMigration' => true,
+                    'dataMode' => 'database',
                 ],
             ],
             new ConfigDefinition(),

--- a/tests/phpunit/MigrateTest.php
+++ b/tests/phpunit/MigrateTest.php
@@ -27,6 +27,45 @@ use stdClass;
 
 class MigrateTest extends TestCase
 {
+    private function createSuccessJobResponse(): Job
+    {
+        return Job::fromApiResponse([
+            'id' => '222',
+            'runId' => 'run-123',
+            'parentRunId' => 'parent-123',
+            'project' => ['id' => '123'],
+            'token' => ['id' => 'token-123', 'description' => null],
+            'status' => 'success',
+            'desiredStatus' => 'processing',
+            'mode' => 'run',
+            'component' => 'test-component',
+            'config' => null,
+            'configData' => null,
+            'configRowIds' => null,
+            'tag' => null,
+            'createdTime' => '2024-01-01T00:00:00+00:00',
+            'startTime' => '2024-01-01T00:00:00+00:00',
+            'endTime' => '2024-01-01T00:00:00+00:00',
+            'durationSeconds' => null,
+            'result' => null,
+            'usageData' => null,
+            'isFinished' => true,
+            'url' => 'https://example.com',
+            'branchId' => null,
+            'variableValuesId' => null,
+            'variableValuesData' => [],
+            'backend' => [],
+            'executor' => null,
+            'metrics' => null,
+            'behavior' => [],
+            'parallelism' => null,
+            'type' => 'container',
+            'orchestrationJobId' => null,
+            'orchestrationTaskId' => null,
+            'onlyOrchestrationTaskIds' => null,
+            'previousJobId' => null,
+        ]);
+    }
 
     /**
      * @param array{
@@ -133,6 +172,7 @@ class MigrateTest extends TestCase
                             'parallelChunks' => 3,
                             'chunkSize' => 150,
                         ],
+                        'replicationStrategy' => 'standalone',
                     ],
                 ],
             ];
@@ -355,6 +395,7 @@ class MigrateTest extends TestCase
                             'parallelChunks' => 10,
                             'chunkSize' => 200,
                         ],
+                        'replicationStrategy' => 'standalone',
                     ],
                 ],
             ],
@@ -457,6 +498,260 @@ class MigrateTest extends TestCase
             new NullLogger(),
         );
 
+        $migrate->run();
+    }
+
+    public function testMigrateReplicationStandaloneParameters(): void
+    {
+        /** @var JobRunner&MockObject $sourceJobRunnerMock */
+        $sourceJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
+        /** @var JobRunner&MockObject $destJobRunnerMock */
+        $destJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
+
+        $this->mockAddMethodGenerateAbsReadCredentials($sourceJobRunnerMock);
+        $this->mockAddMethodBackupProject(
+            $sourceJobRunnerMock,
+            ['id' => '222', 'status' => 'success'],
+            true,
+        );
+
+        $sourceProjectUrl = 'https://connection.keboola.com';
+        $sourceProjectToken = 'xyz';
+
+        $absCredentials = [
+            'abs' => [
+                'container' => 'abcdefgh',
+                '#connectionString' => 'https://testConnectionString',
+            ],
+        ];
+
+        $destinationMockJobs = [
+            [
+                Config::PROJECT_RESTORE_COMPONENT,
+                [
+                    'parameters' => array_merge(
+                        $absCredentials,
+                        [
+                            'useDefaultBackend' => true,
+                            'restoreConfigs' => true,
+                            'dryRun' => false,
+                            'restorePermanentFiles' => true,
+                            'restoreTriggers' => true,
+                            'restoreNotifications' => true,
+                            'restoreBuckets' => true,
+                            'restoreTables' => true,
+                            'restoreProjectMetadata' => true,
+                            'checkEmptyProject' => true,
+                            'forcePrimaryKeyNotNull' => false,
+                            'tableParallelism' => 5,
+                        ],
+                    ),
+                ],
+            ],
+            [
+                Config::DATA_OF_TABLES_MIGRATE_COMPONENT,
+                [
+                    'parameters' => [
+                        'mode' => 'sapi',
+                        'sourceKbcUrl' => $sourceProjectUrl,
+                        '#sourceKbcToken' => $sourceProjectToken,
+                        'dryRun' => false,
+                        'isSourceByodb' => false,
+                        'sourceByodb' => '',
+                        'includeWorkspaceSchemas' => [],
+                        'preserveTimestamp' => false,
+                        'forcePrimaryKeyNotNull' => false,
+                        'gcsLargeTable' => [
+                            'parallelChunks' => 3,
+                            'chunkSize' => 150,
+                        ],
+                        'replicationStrategy' => 'standalone',
+                    ],
+                ],
+            ],
+            [
+                Config::SNOWFLAKE_WRITER_MIGRATE_COMPONENT,
+                [
+                    'parameters' => [
+                        'sourceKbcUrl' => $sourceProjectUrl,
+                        '#sourceKbcToken' => $sourceProjectToken,
+                        'dryRun' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        $destJobRunnerMock->expects($this->exactly(3))
+            ->method('runJob')
+            ->withConsecutive(...$destinationMockJobs)
+            ->willReturn($this->createSuccessJobResponse());
+
+        $config = new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => $sourceProjectUrl,
+                    '#sourceKbcToken' => $sourceProjectToken,
+                    'migrateSecrets' => false,
+                    'directDataMigration' => true,
+                ],
+            ],
+            new ConfigDefinition(),
+        );
+
+        /** @var StorageClient&MockObject $sourceClientMock */
+        $sourceClientMock = $this->createMock(StorageClient::class);
+        $sourceClientMock
+            ->method('apiGet')
+            ->willReturnMap([
+                ['dev-branches/', null, [], [['id' => '123', 'name' => 'default', 'isDefault' => true]]],
+                ['branch/default/components?include=', null, [], []],
+            ]);
+        $sourceClientMock->method('getServiceUrl')->with('encryption')->willReturn('https://encryption.keboola.com');
+        $sourceClientMock->method('generateId')->willReturn('123');
+
+        $destClientMock = $this->createDestClientMock();
+
+        $migrate = new Migrate(
+            $config,
+            $sourceJobRunnerMock,
+            $destJobRunnerMock,
+            $sourceClientMock,
+            $destClientMock,
+            $this->createMock(Migrations::class),
+            'https://dest-stack/',
+            'dest-token',
+            new NullLogger(),
+        );
+        $migrate->run();
+    }
+
+    public function testMigrateReplicationGroupParameters(): void
+    {
+        /** @var JobRunner&MockObject $sourceJobRunnerMock */
+        $sourceJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
+        /** @var JobRunner&MockObject $destJobRunnerMock */
+        $destJobRunnerMock = $this->createMock(QueueV2JobRunner::class);
+
+        $this->mockAddMethodGenerateAbsReadCredentials($sourceJobRunnerMock);
+        $this->mockAddMethodBackupProject(
+            $sourceJobRunnerMock,
+            ['id' => '222', 'status' => 'success'],
+            true,
+        );
+
+        $sourceProjectUrl = 'https://connection.keboola.com';
+        $sourceProjectToken = 'xyz';
+
+        $absCredentials = [
+            'abs' => [
+                'container' => 'abcdefgh',
+                '#connectionString' => 'https://testConnectionString',
+            ],
+        ];
+
+        $destinationMockJobs = [
+            [
+                Config::PROJECT_RESTORE_COMPONENT,
+                [
+                    'parameters' => array_merge(
+                        $absCredentials,
+                        [
+                            'useDefaultBackend' => true,
+                            'restoreConfigs' => true,
+                            'dryRun' => false,
+                            'restorePermanentFiles' => true,
+                            'restoreTriggers' => true,
+                            'restoreNotifications' => true,
+                            'restoreBuckets' => true,
+                            'restoreTables' => true,
+                            'restoreProjectMetadata' => true,
+                            'checkEmptyProject' => true,
+                            'forcePrimaryKeyNotNull' => false,
+                            'tableParallelism' => 5,
+                        ],
+                    ),
+                ],
+            ],
+            [
+                Config::DATA_OF_TABLES_MIGRATE_COMPONENT,
+                [
+                    'parameters' => [
+                        'mode' => 'database',
+                        'sourceKbcUrl' => $sourceProjectUrl,
+                        '#sourceKbcToken' => $sourceProjectToken,
+                        'dryRun' => false,
+                        'isSourceByodb' => false,
+                        'sourceByodb' => '',
+                        'includeWorkspaceSchemas' => [],
+                        'preserveTimestamp' => false,
+                        'forcePrimaryKeyNotNull' => false,
+                        'gcsLargeTable' => [
+                            'parallelChunks' => 3,
+                            'chunkSize' => 150,
+                        ],
+                        'replicationStrategy' => 'group',
+                        'replicationGroup' => [
+                            'name' => 'MIGRATE_RG_1234',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                Config::SNOWFLAKE_WRITER_MIGRATE_COMPONENT,
+                [
+                    'parameters' => [
+                        'sourceKbcUrl' => $sourceProjectUrl,
+                        '#sourceKbcToken' => $sourceProjectToken,
+                        'dryRun' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        $destJobRunnerMock->expects($this->exactly(3))
+            ->method('runJob')
+            ->withConsecutive(...$destinationMockJobs)
+            ->willReturn($this->createSuccessJobResponse());
+
+        $config = new Config(
+            [
+                'parameters' => [
+                    'sourceKbcUrl' => $sourceProjectUrl,
+                    '#sourceKbcToken' => $sourceProjectToken,
+                    'migrateSecrets' => false,
+                    'directDataMigration' => true,
+                    'dataMode' => 'database',
+                    'replicationStrategy' => 'group',
+                    'replicationGroup' => ['name' => 'MIGRATE_RG_1234'],
+                ],
+            ],
+            new ConfigDefinition(),
+        );
+
+        /** @var StorageClient&MockObject $sourceClientMock */
+        $sourceClientMock = $this->createMock(StorageClient::class);
+        $sourceClientMock
+            ->method('apiGet')
+            ->willReturnMap([
+                ['dev-branches/', null, [], [['id' => '123', 'name' => 'default', 'isDefault' => true]]],
+                ['branch/default/components?include=', null, [], []],
+            ]);
+        $sourceClientMock->method('getServiceUrl')->with('encryption')->willReturn('https://encryption.keboola.com');
+        $sourceClientMock->method('generateId')->willReturn('123');
+
+        $destClientMock = $this->createDestClientMock();
+
+        $migrate = new Migrate(
+            $config,
+            $sourceJobRunnerMock,
+            $destJobRunnerMock,
+            $sourceClientMock,
+            $destClientMock,
+            $this->createMock(Migrations::class),
+            'https://dest-stack/',
+            'dest-token',
+            new NullLogger(),
+        );
         $migrate->run();
     }
 


### PR DESCRIPTION
## Summary

Wires the Snowflake **Replication Group** strategy through the orchestrator's Phase 5 (`keboola.app-project-migrate-large-tables`). The component side was added in AJDA-2603; this is the orchestrator-side, config-only wiring.

In `Migrate::migrateDataOfTablesDirectly()` the Phase 5 run parameters now include:

- `replicationStrategy` — always emitted, from a new orchestrator config option (default `standalone`).
- `replicationGroup: { name }` — emitted only when `replicationStrategy: group`.

No `replica.*` flags are passed; the component's defaults handle replica drop behavior (drop in standalone, keep in group).

## Changes

- **`src/ConfigDefinition.php`** — new `replicationStrategy` enum (`standalone` / `group`, default `standalone`) and `replicationGroup.name` node, plus a cross-field validator requiring a non-empty `replicationGroup.name` when strategy is `group`.
- **`src/Config.php`** — getters `getReplicationStrategy()` and `getReplicationGroupName()`.
- **`src/Migrate.php`** — pass-through of the new parameters into Phase 5.
- **`README.md`** / **`docs/configuration.md`** — documented both options, default values, drop behavior, and the manual/ops boundary.
- **Tests** — config getter/default/validation cases and Phase 5 parameter assertions for both standalone and group modes; existing Phase 5 parameter assertions updated for the always-emitted `replicationStrategy`.

## Out of scope (component-handled or manual ops)

- `createReplications` / primary replication group creation.
- Group teardown (`DROP REPLICATION GROUP`).
- Source account identifier derivation (`org.account`) and the same-`db_prefix` restriction — enforced by the component.

## Behavior

- **Standalone** remains the default and is behaviorally unchanged — each per-project run still tears down its own replica.
- **Group** reuses a pre-created shared replication group, which is **not** dropped per run; its teardown is a separate manual/ops step.

Closes AJDA-2881.
